### PR TITLE
Revamp azure service bus and vSLAlpha5 migration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,8 +72,8 @@ jobs:
         env:
             JAVA_HOME: /usr/lib/jvm/default-jvm
             CONNECTION_STRING: ${{ secrets.CONNECTION_STRING }}
-            QUEUE_PATH: ${{ secrets.QUEUE_PATH }}
-            TOPIC_PATH: ${{ secrets.TOPIC_PATH }}
-            SUBSCRIPTION_PATH1: ${{ secrets.SUBSCRIPTION_PATH1 }}
-            SUBSCRIPTION_PATH2: ${{ secrets.SUBSCRIPTION_PATH2 }}
-            SUBSCRIPTION_PATH3: ${{ secrets.SUBSCRIPTION_PATH3 }}
+            QUEUE_PATH: ${{ secrets.QUEUE_NAME }}
+            TOPIC_PATH: ${{ secrets.TOPIC_NAME }}
+            SUBSCRIPTION_PATH1: ${{ secrets.SUBSCRIPTION_NAME1 }}
+            SUBSCRIPTION_PATH2: ${{ secrets.SUBSCRIPTION_NAME2 }}
+            SUBSCRIPTION_PATH3: ${{ secrets.SUBSCRIPTION_NAME3 }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,8 +72,8 @@ jobs:
         env:
             JAVA_HOME: /usr/lib/jvm/default-jvm
             CONNECTION_STRING: ${{ secrets.CONNECTION_STRING }}
-            QUEUE_PATH: ${{ secrets.QUEUE_NAME }}
-            TOPIC_PATH: ${{ secrets.TOPIC_NAME }}
-            SUBSCRIPTION_PATH1: ${{ secrets.SUBSCRIPTION_NAME1 }}
-            SUBSCRIPTION_PATH2: ${{ secrets.SUBSCRIPTION_NAME2 }}
-            SUBSCRIPTION_PATH3: ${{ secrets.SUBSCRIPTION_NAME3 }}
+            QUEUE_NAME: ${{ secrets.QUEUE_NAME }}
+            TOPIC_NAME: ${{ secrets.TOPIC_NAME }}
+            SUBSCRIPTION_NAME1: ${{ secrets.SUBSCRIPTION_NAME1 }}
+            SUBSCRIPTION_NAME2: ${{ secrets.SUBSCRIPTION_NAME2 }}
+            SUBSCRIPTION_NAME3: ${{ secrets.SUBSCRIPTION_NAME3 }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -72,8 +72,8 @@ jobs:
         env:
             JAVA_HOME: /usr/lib/jvm/default-jvm
             CONNECTION_STRING: ${{ secrets.CONNECTION_STRING }}
-            QUEUE_PATH: ${{ secrets.QUEUE_PATH }}
-            TOPIC_PATH: ${{ secrets.TOPIC_PATH }}
-            SUBSCRIPTION_PATH1: ${{ secrets.SUBSCRIPTION_PATH1 }}
-            SUBSCRIPTION_PATH2: ${{ secrets.SUBSCRIPTION_PATH2 }}
-            SUBSCRIPTION_PATH3: ${{ secrets.SUBSCRIPTION_PATH3 }}
+            QUEUE_PATH: ${{ secrets.QUEUE_NAME }}
+            TOPIC_PATH: ${{ secrets.TOPIC_NAME }}
+            SUBSCRIPTION_PATH1: ${{ secrets.SUBSCRIPTION_NAME1 }}
+            SUBSCRIPTION_PATH2: ${{ secrets.SUBSCRIPTION_NAME2 }}
+            SUBSCRIPTION_PATH3: ${{ secrets.SUBSCRIPTION_NAME3 }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -72,8 +72,8 @@ jobs:
         env:
             JAVA_HOME: /usr/lib/jvm/default-jvm
             CONNECTION_STRING: ${{ secrets.CONNECTION_STRING }}
-            QUEUE_PATH: ${{ secrets.QUEUE_NAME }}
-            TOPIC_PATH: ${{ secrets.TOPIC_NAME }}
-            SUBSCRIPTION_PATH1: ${{ secrets.SUBSCRIPTION_NAME1 }}
-            SUBSCRIPTION_PATH2: ${{ secrets.SUBSCRIPTION_NAME2 }}
-            SUBSCRIPTION_PATH3: ${{ secrets.SUBSCRIPTION_NAME3 }}
+            QUEUE_NAME: ${{ secrets.QUEUE_NAME }}
+            TOPIC_NAME: ${{ secrets.TOPIC_NAME }}
+            SUBSCRIPTION_NAME1: ${{ secrets.SUBSCRIPTION_NAME1 }}
+            SUBSCRIPTION_NAME2: ${{ secrets.SUBSCRIPTION_NAME2 }}
+            SUBSCRIPTION_NAME3: ${{ secrets.SUBSCRIPTION_NAME3 }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,11 +74,11 @@ jobs:
         env:
           JAVA_HOME: /usr/lib/jvm/default-jvm
           CONNECTION_STRING: ${{ secrets.CONNECTION_STRING }}
-          QUEUE_PATH: ${{ secrets.QUEUE_NAME }}
-          TOPIC_PATH: ${{ secrets.TOPIC_NAME }}
-          SUBSCRIPTION_PATH1: ${{ secrets.SUBSCRIPTION_NAME1 }}
-          SUBSCRIPTION_PATH2: ${{ secrets.SUBSCRIPTION_NAME2 }}
-          SUBSCRIPTION_PATH3: ${{ secrets.SUBSCRIPTION_NAME3 }}
+          QUEUE_NAME: ${{ secrets.QUEUE_NAME }}
+          TOPIC_NAME: ${{ secrets.TOPIC_NAME }}
+          SUBSCRIPTION_NAME1: ${{ secrets.SUBSCRIPTION_NAME1 }}
+          SUBSCRIPTION_NAME2: ${{ secrets.SUBSCRIPTION_NAME2 }}
+          SUBSCRIPTION_NAME3: ${{ secrets.SUBSCRIPTION_NAME3 }}
 
       # Push to Ballerina Central
       - name: Ballerina Push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,11 +74,11 @@ jobs:
         env:
           JAVA_HOME: /usr/lib/jvm/default-jvm
           CONNECTION_STRING: ${{ secrets.CONNECTION_STRING }}
-          QUEUE_PATH: ${{ secrets.QUEUE_PATH }}
-          TOPIC_PATH: ${{ secrets.TOPIC_PATH }}
-          SUBSCRIPTION_PATH1: ${{ secrets.SUBSCRIPTION_PATH1 }}
-          SUBSCRIPTION_PATH2: ${{ secrets.SUBSCRIPTION_PATH2 }}
-          SUBSCRIPTION_PATH3: ${{ secrets.SUBSCRIPTION_PATH3 }}
+          QUEUE_PATH: ${{ secrets.QUEUE_NAME }}
+          TOPIC_PATH: ${{ secrets.TOPIC_NAME }}
+          SUBSCRIPTION_PATH1: ${{ secrets.SUBSCRIPTION_NAME1 }}
+          SUBSCRIPTION_PATH2: ${{ secrets.SUBSCRIPTION_NAME2 }}
+          SUBSCRIPTION_PATH3: ${{ secrets.SUBSCRIPTION_NAME3 }}
 
       # Push to Ballerina Central
       - name: Ballerina Push

--- a/README.md
+++ b/README.md
@@ -83,8 +83,8 @@ basic operations. These APIs use Shared Access Signature(SAS) authentication and
 * Java 11 Installed
   Java Development Kit (JDK) with version 11 is required.
 
-* Ballerina SLAlpha4 Installed
-  Ballerina Swan Lake Alpha 4 is required.
+* Ballerina SLAlpha5 Installed
+  Ballerina Swan Lake Alpha 5 is required.
 
 * Shared Access Signature (SAS) Authentication Credentials
     * Connection String
@@ -129,7 +129,7 @@ to/from the queue/topic/subscription.
 ## Supported Versions
 |                     |    Version                  |
 |:-------------------:|:---------------------------:|
-| Ballerina Language  | Swan-Lake-Alpha4            |
+| Ballerina Language  | Swan-Lake-Alpha5            |
 | Service Bus API     | v3.5.1                      |
 
 # Quickstart(s)

--- a/README.md
+++ b/README.md
@@ -179,14 +179,14 @@ You can now make an Azure service bus client using the connection configuration.
 ### Step 4: Create a Queue Sender using the Azure service bus client
 You can now make a sender connection using the Azure service bus client. Provide the `queueName` as a parameter.
 ```ballerina
-    checkpanic asbClient->createQueueSender(queueName);
+    handle queueSender = checkpanic asbClient->createQueueSender(queueName);
 ```
 
 ### Step 5 : Create a Queue Receiver using the Azure service bus client
 You can now make a receiver connection using the connection configuration. Provide the `queueName` as a parameter. 
 Optionally you can provide the receive mode which is PEEKLOCK by default.
 ```ballerina
-    checkpanic asbClient->createQueueReceiver(queueName, asb:RECEIVEANDDELETE);
+    handle queueReceiver = checkpanic asbClient->createQueueReceiver(queueName, asb:RECEIVEANDDELETE);
 ```
 
 ### Step 6: Initialize the Input Values
@@ -215,13 +215,13 @@ Initialize the message to be sent with message body, optional parameters and pro
 You can now send a message to the configured azure service bus entity with message body, optional parameters and 
 properties. Here we have shown how to send a text message parsed to the byte array format.
 ```ballerina
-    checkpanic asbClient->send(message1);
+    checkpanic asbClient->send(queueSender, message1);
 ```
 
 ### Step 8: Receive a Message from Azure Service Bus
 You can now receive a message from the configured azure service bus entity.
 ```ballerina
-    asb:Message|asb:Error? messageReceived = asbClient->receive(serverWaitTime);
+    asb:Message|asb:Error? messageReceived = asbClient->receive(queueReceiver, serverWaitTime);
 
     if (messageReceived is asb:Message) {
         log:printInfo("Reading Received Message : " + messageReceived.toString());
@@ -235,13 +235,13 @@ You can now receive a message from the configured azure service bus entity.
 ### Step 9: Close Sender Connection
 You can now close the sender connection.
 ```ballerina
-    checkpanic asbClient->closeSender();
+    checkpanic asbClient->closeSender(queueSender);
 ```
 
 ### Step 10: Close Receiver Connection
 You can now close the receiver connection.
 ```ballerina
-    checkpanic asbClient->closeReceiver();
+    checkpanic asbClient->closeReceiver(queueReceiver);
 ```
 
 ## Send and Listen to Messages from the Azure Service Bus Queue
@@ -289,7 +289,7 @@ You can now make an Azure service bus client using the connection configuration.
 ### Step 4: Create a Queue Sender using the Azure service bus client
 You can now make a sender connection using the Azure service bus client. Provide the `queueName` as a parameter.
 ```ballerina
-    checkpanic asbClient->createQueueSender(queueName);
+    handle queueSender = checkpanic asbClient->createQueueSender(queueName);
 ```
 
 ### Step 5: Initialize the Input Values
@@ -318,19 +318,19 @@ Initialize the message to be sent with message body, optional parameters and pro
 You can now send a message to the configured azure service bus entity with message body, optional parameters and 
 properties. Here we have shown how to send a text message parsed to the byte array format.
 ```ballerina
-    checkpanic asbClient->send(message1);
+    checkpanic asbClient->send(queueSender, message1);
 ```
 
 ### Step 7: Create a service object with the service configuration and the service logic to execute based on the message received
 You can now create a service object with the service configuration specified using the @asb:ServiceConfig annotation. 
-We need to give the connection string and the entity path of the queue we are to listen messages from. Then we can give 
-the service logic to execute when a message is received inside the onMessage remote function.
+We need to give the connection string and the entity path of the queue we are to listen messages from. We can optionally provide the receive mode. Default mode is the PEEKLOCK mode. Then we can give the service logic to execute when a message is received inside the onMessage remote function.
 ```ballerina
     asb:Service asyncTestService =
     @asb:ServiceConfig {
         entityConfig: {
             connectionString: <CONNECTION_STRING>,
-            entityPath: <ENTITY_PATH>
+            entityPath: <ENTITY_PATH>,
+            receiveMode: <PEEKLOCK_OR_RECEIVEONDELETE>
         }
     }
     service object {
@@ -365,12 +365,8 @@ the connection with the Azure Service Bus.
 ### Step 9: Close Sender Connection
 You can now close the sender connection.
 ```ballerina
-    if (senderConnection is asb:SenderConnection) {
-       log:printInfo("Closing Asb sender connection.");
-       checkpanic senderConnection.closeSenderConnection();
-    }
+    checkpanic asbClient->closeSender(queueSender);
 ```
-
 
 # Samples
 
@@ -388,7 +384,7 @@ import ballerinax/asb;
 
 // Connection Configurations
 configurable string connectionString = ?;
-configurable string queuePath = ?;
+configurable string queueName = ?;
 
 public function main() {
 
@@ -417,16 +413,16 @@ public function main() {
     asb:AsbClient asbClient = new (config);
 
     log:printInfo("Creating Asb sender connection.");
-    checkpanic asbClient->createQueueSender(queuePath);
+    handle queueSender = checkpanic asbClient->createQueueSender(queueName);
 
     log:printInfo("Creating Asb receiver connection.");
-    checkpanic asbClient->createQueueReceiver(queuePath, asb:RECEIVEANDDELETE);
+    handle queueReceiver = checkpanic asbClient->createQueueReceiver(queueName, asb:RECEIVEANDDELETE);
 
     log:printInfo("Sending via Asb sender connection.");
-    checkpanic asbClient->send(message1);
+    checkpanic asbClient->send(queueSender, message1);
 
     log:printInfo("Receiving from Asb receiver connection.");
-    asb:Message|asb:Error? messageReceived = asbClient->receive(serverWaitTime);
+    asb:Message|asb:Error? messageReceived = asbClient->receive(queueReceiver, serverWaitTime);
 
     if (messageReceived is asb:Message) {
         log:printInfo("Reading Received Message : " + messageReceived.toString());
@@ -437,10 +433,10 @@ public function main() {
     }
 
     log:printInfo("Closing Asb sender connection.");
-    checkpanic asbClient->closeSender();
+    checkpanic asbClient->closeSender(queueSender);
 
     log:printInfo("Closing Asb receiver connection.");
-    checkpanic asbClient->closeReceiver();
+    checkpanic asbClient->closeReceiver(queueReceiver);
 }    
 ```
 
@@ -458,7 +454,8 @@ import ballerinax/asb;
 
 // Connection Configurations
 configurable string connectionString = ?;
-configurable string queuePath = ?;
+configurable string topicName = ?;
+configurable string subscriptionName1 = ?;
 
 public function main() {
 
@@ -498,16 +495,18 @@ public function main() {
     asb:AsbClient asbClient = new (config);
 
     log:printInfo("Creating Asb sender connection.");
-    checkpanic asbClient->createQueueSender(queuePath);
+    handle topicSender = checkpanic asbClient->createTopicSender(topicName);
 
     log:printInfo("Creating Asb receiver connection.");
-    checkpanic asbClient->createQueueReceiver(queuePath, asb:RECEIVEANDDELETE);
+    handle subscriptionReceiver = 
+        checkpanic asbClient->createSubscriptionReceiver(topicName, subscriptionName1, asb:RECEIVEANDDELETE);
 
     log:printInfo("Sending via Asb sender connection.");
-    checkpanic asbClient->sendBatch(messages);
+    checkpanic asbClient->sendBatch(topicSender, messages);
 
     log:printInfo("Receiving from Asb receiver connection.");
-    asb:MessageBatch|asb:Error? messageReceived = asbClient->receiveBatch(maxMessageCount, serverWaitTime);
+    asb:MessageBatch|asb:Error? messageReceived = 
+        asbClient->receiveBatch(subscriptionReceiver, maxMessageCount, serverWaitTime);
 
     if (messageReceived is asb:MessageBatch) {
         foreach asb:Message message in messageReceived.messages {
@@ -516,16 +515,16 @@ public function main() {
             }
         }
     } else if (messageReceived is ()) {
-        log:printError("No message in the queue.");
+        log:printError("No message in the subscription.");
     } else {
         log:printError("Receiving message via Asb receiver connection failed.");
     }
 
     log:printInfo("Closing Asb sender connection.");
-    checkpanic asbClient->closeSender();
+    checkpanic asbClient->closeSender(topicSender);
 
     log:printInfo("Closing Asb receiver connection.");
-    checkpanic asbClient->closeReceiver();
+    checkpanic asbClient->closeReceiver(subscriptionReceiver);
 }    
 ```
 
@@ -543,8 +542,8 @@ import ballerinax/asb;
 
 // Connection Configurations
 configurable string connectionString = ?;
-configurable string topicPath = ?;
-configurable string subscriptionPath1 = ?;
+configurable string topicName = ?;
+configurable string subscriptionName1 = ?;
 
 public function main() {
 
@@ -573,16 +572,17 @@ public function main() {
     asb:AsbClient asbClient = new (config);
 
     log:printInfo("Creating Asb sender connection.");
-    checkpanic asbClient->createTopicSender(topicPath);
+    handle topicSender = checkpanic asbClient->createTopicSender(topicName);
 
     log:printInfo("Creating Asb receiver connection.");
-    checkpanic asbClient->createSubscriptionReceiver(subscriptionPath1, asb:RECEIVEANDDELETE);
+    handle subscriptionReceiver = 
+        checkpanic asbClient->createSubscriptionReceiver(topicName, subscriptionName1, asb:RECEIVEANDDELETE);
 
     log:printInfo("Sending via Asb sender connection.");
-    checkpanic asbClient->send(message1);
+    checkpanic asbClient->send(topicSender, message1);
 
     log:printInfo("Receiving from Asb receiver connection.");
-    asb:Message|asb:Error? messageReceived = asbClient->receive(serverWaitTime);
+    asb:Message|asb:Error? messageReceived = asbClient->receive(subscriptionReceiver, serverWaitTime);
 
     if (messageReceived is asb:Message) {
         log:printInfo("Reading Received Message : " + messageReceived.toString());
@@ -593,10 +593,10 @@ public function main() {
     }
 
     log:printInfo("Closing Asb sender connection.");
-    checkpanic asbClient->closeSender();
+    checkpanic asbClient->closeSender(topicSender);
 
     log:printInfo("Closing Asb receiver connection.");
-    checkpanic asbClient->closeReceiver();
+    checkpanic asbClient->closeReceiver(subscriptionReceiver);
 }    
 ```
 
@@ -615,8 +615,8 @@ import ballerinax/asb;
 
 // Connection Configurations
 configurable string connectionString = ?;
-configurable string topicPath = ?;
-configurable string subscriptionPath1 = ?;
+configurable string topicName = ?;
+configurable string subscriptionName1 = ?;
 
 public function main() {
 
@@ -656,16 +656,18 @@ public function main() {
     asb:AsbClient asbClient = new (config);
 
     log:printInfo("Creating Asb sender connection.");
-    checkpanic asbClient->createTopicSender(topicPath);
+    handle topicSender = checkpanic asbClient->createTopicSender(topicName);
 
     log:printInfo("Creating Asb receiver connection.");
-    checkpanic asbClient->createSubscriptionReceiver(subscriptionPath1, asb:RECEIVEANDDELETE);
+    handle subscriptionReceiver = 
+        checkpanic asbClient->createSubscriptionReceiver(topicName, subscriptionName1, asb:RECEIVEANDDELETE);
 
     log:printInfo("Sending via Asb sender connection.");
-    checkpanic asbClient->sendBatch(messages);
+    checkpanic asbClient->sendBatch(topicSender, messages);
 
     log:printInfo("Receiving from Asb receiver connection.");
-    asb:MessageBatch|asb:Error? messageReceived = asbClient->receiveBatch(maxMessageCount, serverWaitTime);
+    asb:MessageBatch|asb:Error? messageReceived = 
+        asbClient->receiveBatch(subscriptionReceiver, maxMessageCount, serverWaitTime);
 
     if (messageReceived is asb:MessageBatch) {
         foreach asb:Message message in messageReceived.messages {
@@ -680,10 +682,10 @@ public function main() {
     }
 
     log:printInfo("Closing Asb sender connection.");
-    checkpanic asbClient->closeSender();
+    checkpanic asbClient->closeSender(topicSender);
 
     log:printInfo("Closing Asb receiver connection.");
-    checkpanic asbClient->closeReceiver();
+    checkpanic asbClient->closeReceiver(subscriptionReceiver);
 }    
 ```
 
@@ -701,7 +703,7 @@ import ballerinax/asb;
 
 // Connection Configurations
 configurable string connectionString = ?;
-configurable string queuePath = ?;
+configurable string queueName = ?;
 
 public function main() {
 
@@ -730,19 +732,19 @@ public function main() {
     asb:AsbClient asbClient = new (config);
 
     log:printInfo("Creating Asb sender connection.");
-    checkpanic asbClient->createQueueSender(queuePath);
+    handle queueSender = checkpanic asbClient->createQueueSender(queueName);
 
     log:printInfo("Creating Asb receiver connection.");
-    checkpanic asbClient->createQueueReceiver(queuePath, asb:PEEKLOCK);
+    handle queueReceiver = checkpanic asbClient->createQueueReceiver(queueName, asb:PEEKLOCK);
 
     log:printInfo("Sending via Asb sender connection.");
-    checkpanic asbClient->send(message1);
+    checkpanic asbClient->send(queueSender, message1);
 
     log:printInfo("Receiving from Asb receiver connection.");
-    asb:Message|asb:Error? messageReceived = asbClient->receive(serverWaitTime);
+    asb:Message|asb:Error? messageReceived = asbClient->receive(queueReceiver, serverWaitTime);
 
     if (messageReceived is asb:Message) {
-        checkpanic asbClient->complete(messageReceived);
+        checkpanic asbClient->complete(queueReceiver, messageReceived);
         log:printInfo("Complete message successful");
     } else if (messageReceived is ()) {
         log:printError("No message in the queue.");
@@ -751,10 +753,10 @@ public function main() {
     }
 
     log:printInfo("Closing Asb sender connection.");
-    checkpanic asbClient->closeSender();
+    checkpanic asbClient->closeSender(queueSender);
 
     log:printInfo("Closing Asb receiver connection.");
-    checkpanic asbClient->closeReceiver();
+    checkpanic asbClient->closeReceiver(queueReceiver);
 }    
 ```
 
@@ -772,8 +774,8 @@ import ballerinax/asb;
 
 // Connection Configurations
 configurable string connectionString = ?;
-configurable string topicPath = ?;
-configurable string subscriptionPath1 = ?;
+configurable string topicName = ?;
+configurable string subscriptionName1 = ?;
 
 public function main() {
 
@@ -802,19 +804,20 @@ public function main() {
     asb:AsbClient asbClient = new (config);
 
     log:printInfo("Creating Asb sender connection.");
-    checkpanic asbClient->createTopicSender(topicPath);
+    handle topicSender = checkpanic asbClient->createTopicSender(topicName);
 
     log:printInfo("Creating Asb receiver connection.");
-    checkpanic asbClient->createSubscriptionReceiver(subscriptionPath1, asb:PEEKLOCK);
+    handle subscriptionReceiver = 
+        checkpanic asbClient->createSubscriptionReceiver(topicName, subscriptionName1, asb:PEEKLOCK);
 
     log:printInfo("Sending via Asb sender connection.");
-    checkpanic asbClient->send(message1);
+    checkpanic asbClient->send(topicSender, message1);
 
     log:printInfo("Receiving from Asb receiver connection.");
-    asb:Message|asb:Error? messageReceived = asbClient->receive(serverWaitTime);
+    asb:Message|asb:Error? messageReceived = asbClient->receive(subscriptionReceiver, serverWaitTime);
 
     if (messageReceived is asb:Message) {
-        checkpanic asbClient->complete(messageReceived);
+        checkpanic asbClient->complete(subscriptionReceiver, messageReceived);
         log:printInfo("Complete message successful");
     } else if (messageReceived is ()) {
         log:printError("No message in the subscription.");
@@ -823,10 +826,10 @@ public function main() {
     }
 
     log:printInfo("Closing Asb sender connection.");
-    checkpanic asbClient->closeSender();
+    checkpanic asbClient->closeSender(topicSender);
 
     log:printInfo("Closing Asb receiver connection.");
-    checkpanic asbClient->closeReceiver();
+    checkpanic asbClient->closeReceiver(subscriptionReceiver);
 }    
 ```
 
@@ -845,7 +848,7 @@ import ballerinax/asb;
 
 // Connection Configurations
 configurable string connectionString = ?;
-configurable string queuePath = ?;
+configurable string queueName = ?;
 
 public function main() {
 
@@ -874,22 +877,22 @@ public function main() {
     asb:AsbClient asbClient = new (config);
 
     log:printInfo("Creating Asb sender connection.");
-    checkpanic asbClient->createQueueSender(queuePath);
+    handle queueSender = checkpanic asbClient->createQueueSender(queueName);
 
     log:printInfo("Creating Asb receiver connection.");
-    checkpanic asbClient->createQueueReceiver(queuePath, asb:PEEKLOCK);
+    handle queueReceiver = checkpanic asbClient->createQueueReceiver(queueName, asb:PEEKLOCK);
 
     log:printInfo("Sending via Asb sender connection.");
-    checkpanic asbClient->send(message1);
+    checkpanic asbClient->send(queueSender, message1);
 
     log:printInfo("Receiving from Asb receiver connection.");
-    asb:Message|asb:Error? messageReceived = asbClient->receive(serverWaitTime);
+    asb:Message|asb:Error? messageReceived = asbClient->receive(queueReceiver, serverWaitTime);
 
     if (messageReceived is asb:Message) {
-        checkpanic asbClient->abandon(messageReceived);
-        asb:Message|asb:Error? messageReceivedAgain = asbClient->receive(serverWaitTime);
+        checkpanic asbClient->abandon(queueReceiver, messageReceived);
+        asb:Message|asb:Error? messageReceivedAgain = asbClient->receive(queueReceiver, serverWaitTime);
         if (messageReceivedAgain is asb:Message) {
-            checkpanic asbClient->complete(messageReceivedAgain);
+            checkpanic asbClient->complete(queueReceiver, messageReceivedAgain);
             log:printInfo("Abandon message successful");
         } else {
             log:printError("Abandon message not succesful.");
@@ -901,10 +904,10 @@ public function main() {
     }
 
     log:printInfo("Closing Asb sender connection.");
-    checkpanic asbClient->closeSender();
+    checkpanic asbClient->closeSender(queueSender);
 
     log:printInfo("Closing Asb receiver connection.");
-    checkpanic asbClient->closeReceiver();
+    checkpanic asbClient->closeReceiver(queueReceiver);
 }    
 ```
 
@@ -923,8 +926,8 @@ import ballerinax/asb;
 
 // Connection Configurations
 configurable string connectionString = ?;
-configurable string topicPath = ?;
-configurable string subscriptionPath1 = ?;
+configurable string topicName = ?;
+configurable string subscriptionName1 = ?;
 
 public function main() {
 
@@ -953,22 +956,23 @@ public function main() {
     asb:AsbClient asbClient = new (config);
 
     log:printInfo("Creating Asb sender connection.");
-    checkpanic asbClient->createTopicSender(topicPath);
+    handle topicSender = checkpanic asbClient->createTopicSender(topicName);
 
     log:printInfo("Creating Asb receiver connection.");
-    checkpanic asbClient->createSubscriptionReceiver(subscriptionPath1, asb:PEEKLOCK);
+    handle subscriptionReceiver = 
+        checkpanic asbClient->createSubscriptionReceiver(topicName, subscriptionName1, asb:PEEKLOCK);
 
     log:printInfo("Sending via Asb sender connection.");
-    checkpanic asbClient->send(message1);
+    checkpanic asbClient->send(topicSender, message1);
 
     log:printInfo("Receiving from Asb receiver connection.");
-    asb:Message|asb:Error? messageReceived = asbClient->receive(serverWaitTime);
+    asb:Message|asb:Error? messageReceived = asbClient->receive(subscriptionReceiver, serverWaitTime);
 
     if (messageReceived is asb:Message) {
-        checkpanic asbClient->abandon(messageReceived);
-        asb:Message|asb:Error? messageReceivedAgain = asbClient->receive(serverWaitTime);
+        checkpanic asbClient->abandon(subscriptionReceiver, messageReceived);
+        asb:Message|asb:Error? messageReceivedAgain = asbClient->receive(subscriptionReceiver, serverWaitTime);
         if (messageReceivedAgain is asb:Message) {
-            checkpanic asbClient->complete(messageReceivedAgain);
+            checkpanic asbClient->complete(subscriptionReceiver, messageReceivedAgain);
             log:printInfo("Abandon message successful");
         } else {
             log:printError("Abandon message not succesful.");
@@ -980,10 +984,10 @@ public function main() {
     }
 
     log:printInfo("Closing Asb sender connection.");
-    checkpanic asbClient->closeSender();
+    checkpanic asbClient->closeSender(topicSender);
 
     log:printInfo("Closing Asb receiver connection.");
-    checkpanic asbClient->closeReceiver();
+    checkpanic asbClient->closeReceiver(subscriptionReceiver);
 }    
 ```
 
@@ -1004,7 +1008,7 @@ import ballerinax/asb;
 
 // Connection Configurations
 configurable string connectionString = ?;
-configurable string queuePath = ?;
+configurable string queueName = ?;
 
 public function main() {
 
@@ -1032,16 +1036,16 @@ public function main() {
     asb:AsbClient asbClient = new (config);
 
     log:printInfo("Creating Asb sender connection.");
-    checkpanic asbClient->createQueueSender(queuePath);
+    handle queueSender = checkpanic asbClient->createQueueSender(queueName);
 
     log:printInfo("Sending via Asb sender connection.");
-    checkpanic asbClient->send(message1);
+    checkpanic asbClient->send(queueSender, message1);
 
     asb:Service asyncTestService =
     @asb:ServiceConfig {
         entityConfig: {
             connectionString: connectionString,
-            entityPath: queuePath
+            entityPath: queueName
         }
     }
     service object {
@@ -1064,7 +1068,7 @@ public function main() {
     }
 
     log:printInfo("Closing Asb sender connection.");
-    checkpanic asbClient->closeSender();
+    checkpanic asbClient->closeSender(queueSender);
 }    
 ```
 
@@ -1083,7 +1087,7 @@ import ballerinax/asb;
 
 // Connection Configurations
 configurable string connectionString = ?;
-configurable string queuePath = ?;
+configurable string queueName = ?;
 
 public function main() {
 
@@ -1112,20 +1116,20 @@ public function main() {
     asb:AsbClient asbClient = new (config);
 
     log:printInfo("Creating Asb sender connection.");
-    checkpanic asbClient->createQueueSender(queuePath);
+    handle queueSender = checkpanic asbClient->createQueueSender(queueName);
 
     log:printInfo("Creating Asb receiver connection.");
-    checkpanic asbClient->createQueueReceiver(queuePath, asb:PEEKLOCK);
+    handle queueReceiver = checkpanic asbClient->createQueueReceiver(queueName, asb:PEEKLOCK);
 
     log:printInfo("Sending via Asb sender connection.");
-    checkpanic asbClient->send(message1);
+    checkpanic asbClient->send(queueSender, message1);
 
     log:printInfo("Receiving from Asb receiver connection.");
-    asb:Message|asb:Error? messageReceived = asbClient->receive(serverWaitTime);
+    asb:Message|asb:Error? messageReceived = asbClient->receive(queueReceiver, serverWaitTime);
 
     if (messageReceived is asb:Message) {
-        checkpanic asbClient->deadLetter(messageReceived);
-        asb:Message|asb:Error? messageReceivedAgain = asbClient->receive(serverWaitTime);
+        checkpanic asbClient->deadLetter(queueReceiver, messageReceived);
+        asb:Message|asb:Error? messageReceivedAgain = asbClient->receive(queueReceiver, serverWaitTime);
         if (messageReceivedAgain is ()) {
             log:printInfo("Deadletter message successful");
         } else {
@@ -1138,10 +1142,10 @@ public function main() {
     }
 
     log:printInfo("Closing Asb sender connection.");
-    checkpanic asbClient->closeSender();
+    checkpanic asbClient->closeSender(queueSender);
 
     log:printInfo("Closing Asb receiver connection.");
-    checkpanic asbClient->closeReceiver();
+    checkpanic asbClient->closeReceiver(queueReceiver);
 }    
 ```
 
@@ -1160,8 +1164,8 @@ import ballerinax/asb;
 
 // Connection Configurations
 configurable string connectionString = ?;
-configurable string topicPath = ?;
-configurable string subscriptionPath1 = ?;
+configurable string topicName = ?;
+configurable string subscriptionName1 = ?;
 
 public function main() {
 
@@ -1190,20 +1194,21 @@ public function main() {
     asb:AsbClient asbClient = new (config);
 
     log:printInfo("Creating Asb sender connection.");
-    checkpanic asbClient->createTopicSender(topicPath);
+    handle topicSender = checkpanic asbClient->createTopicSender(topicName);
 
     log:printInfo("Creating Asb receiver connection.");
-    checkpanic asbClient->createSubscriptionReceiver(subscriptionPath1, asb:PEEKLOCK);
+    handle subscriptionReceiver = 
+        checkpanic asbClient->createSubscriptionReceiver(topicName, subscriptionName1, asb:PEEKLOCK);
 
     log:printInfo("Sending via Asb sender connection.");
-    checkpanic asbClient->send(message1);
+    checkpanic asbClient->send(topicSender, message1);
 
     log:printInfo("Receiving from Asb receiver connection.");
-    asb:Message|asb:Error? messageReceived = asbClient->receive(serverWaitTime);
+    asb:Message|asb:Error? messageReceived = asbClient->receive(subscriptionReceiver, serverWaitTime);
 
     if (messageReceived is asb:Message) {
-        checkpanic asbClient->deadLetter(messageReceived);
-        asb:Message|asb:Error? messageReceivedAgain = asbClient->receive(serverWaitTime);
+        checkpanic asbClient->deadLetter(subscriptionReceiver, messageReceived);
+        asb:Message|asb:Error? messageReceivedAgain = asbClient->receive(subscriptionReceiver, serverWaitTime);
         if (messageReceivedAgain is ()) {
             log:printInfo("Deadletter message successful");
         } else {
@@ -1216,10 +1221,10 @@ public function main() {
     }
 
     log:printInfo("Closing Asb sender connection.");
-    checkpanic asbClient->closeSender();
+    checkpanic asbClient->closeSender(topicSender);
 
     log:printInfo("Closing Asb receiver connection.");
-    checkpanic asbClient->closeReceiver();
+    checkpanic asbClient->closeReceiver(subscriptionReceiver);
 }    
 ```
 
@@ -1238,7 +1243,7 @@ import ballerinax/asb;
 
 // Connection Configurations
 configurable string connectionString = ?;
-configurable string queuePath = ?;
+configurable string queueName = ?;
 
 public function main() {
 
@@ -1267,21 +1272,22 @@ public function main() {
     asb:AsbClient asbClient = new (config);
 
     log:printInfo("Creating Asb sender connection.");
-    checkpanic asbClient->createQueueSender(queuePath);
+    handle queueSender = checkpanic asbClient->createQueueSender(queueName);
 
     log:printInfo("Creating Asb receiver connection.");
-    checkpanic asbClient->createQueueReceiver(queuePath, asb:PEEKLOCK);
+    handle queueReceiver = checkpanic asbClient->createQueueReceiver(queueName, asb:PEEKLOCK);
 
     log:printInfo("Sending via Asb sender connection.");
-    checkpanic asbClient->send(message1);
+    checkpanic asbClient->send(queueSender, message1);
 
     log:printInfo("Receiving from Asb receiver connection.");
-    asb:Message|asb:Error? messageReceived = asbClient->receive(serverWaitTime);
+    asb:Message|asb:Error? messageReceived = asbClient->receive(queueReceiver, serverWaitTime);
 
     if (messageReceived is asb:Message) {
-        int sequenceNumber = checkpanic asbClient->defer(messageReceived);
+        int sequenceNumber = checkpanic asbClient->defer(queueReceiver, messageReceived);
         log:printInfo("Defer message successful");
-        asb:Message|asb:Error? messageReceivedAgain = checkpanic asbClient->receiveDeferred(sequenceNumber);
+        asb:Message|asb:Error? messageReceivedAgain = 
+            checkpanic asbClient->receiveDeferred(queueReceiver,sequenceNumber);
         if (messageReceivedAgain is asb:Message) {
             log:printInfo("Reading Deferred Message : " + messageReceivedAgain.toString());
         }
@@ -1292,10 +1298,10 @@ public function main() {
     }
 
     log:printInfo("Closing Asb sender connection.");
-    checkpanic asbClient->closeSender();
+    checkpanic asbClient->closeSender(queueSender);
 
     log:printInfo("Closing Asb receiver connection.");
-    checkpanic asbClient->closeReceiver();
+    checkpanic asbClient->closeReceiver(queueReceiver);
 }    
 ```
 
@@ -1314,8 +1320,8 @@ import ballerinax/asb;
 
 // Connection Configurations
 configurable string connectionString = ?;
-configurable string topicPath = ?;
-configurable string subscriptionPath1 = ?;
+configurable string topicName = ?;
+configurable string subscriptionName1 = ?;
 
 public function main() {
 
@@ -1344,21 +1350,23 @@ public function main() {
     asb:AsbClient asbClient = new (config);
 
     log:printInfo("Creating Asb sender connection.");
-    checkpanic asbClient->createTopicSender(topicPath);
+    handle topicSender = checkpanic asbClient->createTopicSender(topicName);
 
     log:printInfo("Creating Asb receiver connection.");
-    checkpanic asbClient->createSubscriptionReceiver(subscriptionPath1, asb:PEEKLOCK);
+    handle subscriptionReceiver = 
+        checkpanic asbClient->createSubscriptionReceiver(topicName, subscriptionName1, asb:PEEKLOCK);
 
     log:printInfo("Sending via Asb sender connection.");
-    checkpanic asbClient->send(message1);
+    checkpanic asbClient->send(topicSender, message1);
 
     log:printInfo("Receiving from Asb receiver connection.");
-    asb:Message|asb:Error? messageReceived = asbClient->receive(serverWaitTime);
+    asb:Message|asb:Error? messageReceived = asbClient->receive(subscriptionReceiver, serverWaitTime);
 
     if (messageReceived is asb:Message) {
-        int sequenceNumber = checkpanic asbClient->defer(messageReceived);
+        int sequenceNumber = checkpanic asbClient->defer(subscriptionReceiver, messageReceived);
         log:printInfo("Defer message successful");
-        asb:Message|asb:Error? messageReceivedAgain = checkpanic asbClient->receiveDeferred(sequenceNumber);
+        asb:Message|asb:Error? messageReceivedAgain = 
+            checkpanic asbClient->receiveDeferred(subscriptionReceiver, sequenceNumber);
         if (messageReceivedAgain is asb:Message) {
             log:printInfo("Reading Deferred Message : " + messageReceivedAgain.toString());
         }
@@ -1369,10 +1377,10 @@ public function main() {
     }
 
     log:printInfo("Closing Asb sender connection.");
-    checkpanic asbClient->closeSender();
+    checkpanic asbClient->closeSender(topicSender);
 
     log:printInfo("Closing Asb receiver connection.");
-    checkpanic asbClient->closeReceiver();
+    checkpanic asbClient->closeReceiver(subscriptionReceiver);
 }    
 ```
 
@@ -1391,7 +1399,7 @@ import ballerinax/asb;
 
 // Connection Configurations
 configurable string connectionString = ?;
-configurable string queuePath = ?;
+configurable string queueName = ?;
 
 public function main() {
 
@@ -1420,25 +1428,20 @@ public function main() {
     asb:AsbClient asbClient = new (config);
 
     log:printInfo("Creating Asb sender connection.");
-    checkpanic asbClient->createQueueSender(queuePath);
+    handle queueSender = checkpanic asbClient->createQueueSender(queueName);
 
     log:printInfo("Creating Asb receiver connection.");
-    checkpanic asbClient->createQueueReceiver(queuePath, asb:PEEKLOCK);
+    handle queueReceiver = checkpanic asbClient->createQueueReceiver(queueName, asb:PEEKLOCK);
 
     log:printInfo("Sending via Asb sender connection.");
-    checkpanic asbClient->send(message1);
+    checkpanic asbClient->send(queueSender, message1);
 
     log:printInfo("Receiving from Asb receiver connection.");
-    asb:Message|asb:Error? messageReceived = asbClient->receive(serverWaitTime);
+    asb:Message|asb:Error? messageReceived = asbClient->receive(queueReceiver, serverWaitTime);
 
     if (messageReceived is asb:Message) {
-        checkpanic asbClient->renewLock(messageReceived);
-        asb:Message|asb:Error? messageReceivedAgain = asbClient->receive(serverWaitTime);
-        if (messageReceivedAgain is ()) {
-            log:printInfo("Renew lock message successful");
-        } else {
-            log:printError("Renew lock on message not succesful.");
-        }
+        checkpanic asbClient->renewLock(queueReceiver, messageReceived);
+        log:printInfo("Renew lock message successful");
     } else if (messageReceived is ()) {
         log:printError("No message in the queue.");
     } else {
@@ -1446,10 +1449,10 @@ public function main() {
     }
 
     log:printInfo("Closing Asb sender connection.");
-    checkpanic asbClient->closeSender();
+    checkpanic asbClient->closeSender(queueSender);
 
     log:printInfo("Closing Asb receiver connection.");
-    checkpanic asbClient->closeReceiver();
+    checkpanic asbClient->closeReceiver(queueReceiver);
 }    
 ```
 
@@ -1468,8 +1471,8 @@ import ballerinax/asb;
 
 // Connection Configurations
 configurable string connectionString = ?;
-configurable string topicPath = ?;
-configurable string subscriptionPath1 = ?;
+configurable string topicName = ?;
+configurable string subscriptionName1 = ?;
 
 public function main() {
 
@@ -1498,25 +1501,22 @@ public function main() {
     asb:AsbClient asbClient = new (config);
 
     log:printInfo("Creating Asb sender connection.");
-    checkpanic asbClient->createTopicSender(topicPath);
+    handle topicSender = checkpanic asbClient->createTopicSender(topicName);
 
     log:printInfo("Creating Asb receiver connection.");
-    checkpanic asbClient->createSubscriptionReceiver(subscriptionPath1, asb:PEEKLOCK);
+    handle subscriptionReceiver = 
+        checkpanic asbClient->createSubscriptionReceiver(topicName, subscriptionName1, asb:PEEKLOCK);
     
     log:printInfo("Sending via Asb sender connection.");
-    checkpanic asbClient->send(message1);
+    checkpanic asbClient->send(topicSender, message1);
 
     log:printInfo("Receiving from Asb receiver connection.");
-    asb:Message|asb:Error? messageReceived = asbClient->receive(serverWaitTime);
+    asb:Message|asb:Error? messageReceived = asbClient->receive(subscriptionReceiver, serverWaitTime);
 
     if (messageReceived is asb:Message) {
-        checkpanic asbClient->renewLock(messageReceived);
-        asb:Message|asb:Error? messageReceivedAgain = asbClient->receive(serverWaitTime);
-        if (messageReceivedAgain is ()) {
-            log:printInfo("Renew lock message successful");
-        } else {
-            log:printError("Renew lock on message not succesful.");
-        }
+        checkpanic asbClient->renewLock(subscriptionReceiver, messageReceived);
+        asb:Message|asb:Error? messageReceivedAgain = asbClient->receive(subscriptionReceiver, serverWaitTime);
+        log:printInfo("Renew lock message successful");
     } else if (messageReceived is ()) {
         log:printError("No message in the queue.");
     } else {
@@ -1524,10 +1524,10 @@ public function main() {
     }
 
     log:printInfo("Closing Asb sender connection.");
-    checkpanic asbClient->closeSender();
+    checkpanic asbClient->closeSender(topicSender);
 
     log:printInfo("Closing Asb receiver connection.");
-    checkpanic asbClient->closeReceiver();
+    checkpanic asbClient->closeReceiver(subscriptionReceiver);
 }    
 ```
 

--- a/asb-ballerina/Ballerina.toml
+++ b/asb-ballerina/Ballerina.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/ballerina-platform/module-ballerinax-azure-serv
 observabilityIncluded = true
 
 [[platform.java11.dependency]]
-path = "../asb-native/target/asb-native-1.0.1-jar-with-dependencies.jar"
+path = "../asb-native/target/asb-native-1.0.2-jar-with-dependencies.jar"
 groupId = "org.ballerinalang"
 artifactId = "asb-native"
 module = "asb-native" 

--- a/asb-ballerina/Ballerina.toml
+++ b/asb-ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerinax"
 name = "asb"
-version = "0.1.2"
+version = "0.1.3"
 license= ["Apache-2.0"]
 authors = ["Ballerina"]
 keywords = ["Azure","ServiceBus"]

--- a/asb-ballerina/Dependencies.toml
+++ b/asb-ballerina/Dependencies.toml
@@ -6,16 +6,16 @@ version = "0.0.0"
 [[dependency]]
 org = "ballerina"
 name = "time"
-version = "2.0.0-alpha8"
+version = "2.0.0-alpha9"
 
 [[dependency]]
 org = "ballerina"
 name = "log"
-version = "1.1.0-alpha7"
+version = "1.1.0-alpha8"
 
 [[dependency]]
 org = "ballerina"
 name = "os"
-version = "0.8.0-alpha7"
+version = "0.8.0-alpha8"
 
 

--- a/asb-ballerina/Module.md
+++ b/asb-ballerina/Module.md
@@ -126,14 +126,14 @@ You can now make an Azure service bus client using the connection configuration.
 ### Step 4: Create a Queue Sender using the Azure service bus client
 You can now make a sender connection using the Azure service bus client. Provide the `queueName` as a parameter.
 ```ballerina
-    checkpanic asbClient->createQueueSender(queueName);
+    handle queueSender = checkpanic asbClient->createQueueSender(queueName);
 ```
 
 ### Step 5 : Create a Queue Receiver using the Azure service bus client
 You can now make a receiver connection using the connection configuration. Provide the `queueName` as a parameter. 
 Optionally you can provide the receive mode which is PEEKLOCK by default.
 ```ballerina
-    checkpanic asbClient->createQueueReceiver(queueName, asb:RECEIVEANDDELETE);
+    handle queueReceiver = checkpanic asbClient->createQueueReceiver(queueName, asb:RECEIVEANDDELETE);
 ```
 
 ### Step 6: Initialize the Input Values
@@ -162,13 +162,13 @@ Initialize the message to be sent with message body, optional parameters and pro
 You can now send a message to the configured azure service bus entity with message body, optional parameters and 
 properties. Here we have shown how to send a text message parsed to the byte array format.
 ```ballerina
-    checkpanic asbClient->send(message1);
+    checkpanic asbClient->send(queueSender, message1);
 ```
 
 ### Step 8: Receive a Message from Azure Service Bus
 You can now receive a message from the configured azure service bus entity.
 ```ballerina
-    asb:Message|asb:Error? messageReceived = asbClient->receive(serverWaitTime);
+    asb:Message|asb:Error? messageReceived = asbClient->receive(queueReceiver, serverWaitTime);
 
     if (messageReceived is asb:Message) {
         log:printInfo("Reading Received Message : " + messageReceived.toString());
@@ -182,13 +182,13 @@ You can now receive a message from the configured azure service bus entity.
 ### Step 9: Close Sender Connection
 You can now close the sender connection.
 ```ballerina
-    checkpanic asbClient->closeSender();
+    checkpanic asbClient->closeSender(queueSender);
 ```
 
 ### Step 10: Close Receiver Connection
 You can now close the receiver connection.
 ```ballerina
-    checkpanic asbClient->closeReceiver();
+    checkpanic asbClient->closeReceiver(queueReceiver);
 ```
 
 Sample is available at:
@@ -222,7 +222,7 @@ You can now make an Azure service bus client using the connection configuration.
 ### Step 4: Create a Queue Sender using the Azure service bus client
 You can now make a sender connection using the Azure service bus client. Provide the `queueName` as a parameter.
 ```ballerina
-    checkpanic asbClient->createQueueSender(queueName);
+    handle queueSender = checkpanic asbClient->createQueueSender(queueName);
 ```
 
 ### Step 5: Initialize the Input Values
@@ -251,19 +251,19 @@ Initialize the message to be sent with message body, optional parameters and pro
 You can now send a message to the configured azure service bus entity with message body, optional parameters and 
 properties. Here we have shown how to send a text message parsed to the byte array format.
 ```ballerina
-    checkpanic asbClient->send(message1);
+    checkpanic asbClient->send(queueSender, message1);
 ```
 
 ### Step 7: Create a service object with the service configuration and the service logic to execute based on the message received
 You can now create a service object with the service configuration specified using the @asb:ServiceConfig annotation. 
-We need to give the connection string and the entity path of the queue we are to listen messages from. Then we can give 
-the service logic to execute when a message is received inside the onMessage remote function.
+We need to give the connection string and the entity path of the queue we are to listen messages from. We can optionally provide the receive mode. Default mode is the PEEKLOCK mode. Then we can give the service logic to execute when a message is received inside the onMessage remote function.
 ```ballerina
     asb:Service asyncTestService =
     @asb:ServiceConfig {
         entityConfig: {
             connectionString: <CONNECTION_STRING>,
-            entityPath: <ENTITY_PATH>
+            entityPath: <ENTITY_PATH>,
+            receiveMode: <PEEKLOCK_OR_RECEIVEONDELETE>
         }
     }
     service object {
@@ -298,10 +298,7 @@ the connection with the Azure Service Bus.
 ### Step 8: Close Sender Connection
 You can now close the sender connection.
 ```ballerina
-    if (senderConnection is asb:SenderConnection) {
-       log:printInfo("Closing Asb sender connection.");
-       checkpanic senderConnection.closeSenderConnection();
-    }
+    checkpanic asbClient->closeSender(queueSender);
 ```
 
 Sample is available at:
@@ -325,7 +322,7 @@ import ballerinax/asb;
 
 // Connection Configurations
 configurable string connectionString = ?;
-configurable string queuePath = ?;
+configurable string queueName = ?;
 
 public function main() {
 
@@ -365,16 +362,17 @@ public function main() {
     asb:AsbClient asbClient = new (config);
 
     log:printInfo("Creating Asb sender connection.");
-    checkpanic asbClient->createQueueSender(queuePath);
+    handle queueSender = checkpanic asbClient->createQueueSender(queueName);
 
     log:printInfo("Creating Asb receiver connection.");
-    checkpanic asbClient->createQueueReceiver(queuePath, asb:RECEIVEANDDELETE);
+    handle queueReceiver = checkpanic asbClient->createQueueReceiver(queueName, asb:RECEIVEANDDELETE);
 
     log:printInfo("Sending via Asb sender connection.");
-    checkpanic asbClient->sendBatch(messages);
+    checkpanic asbClient->sendBatch(queueSender, messages);
 
     log:printInfo("Receiving from Asb receiver connection.");
-    asb:MessageBatch|asb:Error? messageReceived = asbClient->receiveBatch(maxMessageCount, serverWaitTime);
+    asb:MessageBatch|asb:Error? messageReceived = 
+        asbClient->receiveBatch(queueReceiver, maxMessageCount, serverWaitTime);
 
     if (messageReceived is asb:MessageBatch) {
         foreach asb:Message message in messageReceived.messages {
@@ -389,10 +387,10 @@ public function main() {
     }
 
     log:printInfo("Closing Asb sender connection.");
-    checkpanic asbClient->closeSender();
+    checkpanic asbClient->closeSender(queueSender);
 
     log:printInfo("Closing Asb receiver connection.");
-    checkpanic asbClient->closeReceiver();
+    checkpanic asbClient->closeReceiver(queueReceiver);
 }    
 ```
 
@@ -411,8 +409,8 @@ import ballerinax/asb;
 
 // Connection Configurations
 configurable string connectionString = ?;
-configurable string topicPath = ?;
-configurable string subscriptionPath1 = ?;
+configurable string topicName = ?;
+configurable string subscriptionName1 = ?;
 
 public function main() {
 
@@ -441,16 +439,17 @@ public function main() {
     asb:AsbClient asbClient = new (config);
 
     log:printInfo("Creating Asb sender connection.");
-    checkpanic asbClient->createTopicSender(topicPath);
+    handle topicSender = checkpanic asbClient->createTopicSender(topicName);
 
     log:printInfo("Creating Asb receiver connection.");
-    checkpanic asbClient->createSubscriptionReceiver(subscriptionPath1, asb:RECEIVEANDDELETE);
+    handle subscriptionReceiver = 
+        checkpanic asbClient->createSubscriptionReceiver(topicName, subscriptionName1, asb:RECEIVEANDDELETE);
 
     log:printInfo("Sending via Asb sender connection.");
-    checkpanic asbClient->send(message1);
+    checkpanic asbClient->send(topicSender, message1);
 
     log:printInfo("Receiving from Asb receiver connection.");
-    asb:Message|asb:Error? messageReceived = asbClient->receive(serverWaitTime);
+    asb:Message|asb:Error? messageReceived = asbClient->receive(subscriptionReceiver, serverWaitTime);
 
     if (messageReceived is asb:Message) {
         log:printInfo("Reading Received Message : " + messageReceived.toString());
@@ -461,10 +460,10 @@ public function main() {
     }
 
     log:printInfo("Closing Asb sender connection.");
-    checkpanic asbClient->closeSender();
+    checkpanic asbClient->closeSender(topicSender);
 
     log:printInfo("Closing Asb receiver connection.");
-    checkpanic asbClient->closeReceiver();
+    checkpanic asbClient->closeReceiver(subscriptionReceiver);
 }    
 ```
 

--- a/asb-ballerina/Module.md
+++ b/asb-ballerina/Module.md
@@ -13,7 +13,7 @@ basic operations. These APIs use SAS authentication and this module supports SAS
 # Compatibility
 |                     |    Version                  |
 |:-------------------:|:---------------------------:|
-| Ballerina Language  | Swan-Lake-Alpha4            |
+| Ballerina Language  | Swan-Lake-Alpha5            |
 | Service Bus API     | v3.5.1                      |
 
 # Supported Operations
@@ -56,8 +56,8 @@ immediate stop listening.
 * Java 11 Installed
   Java Development Kit (JDK) with version 11 is required.
 
-* Ballerina SLAlpha4 Installed
-  Ballerina Swan Lake Alpha 4 is required.
+* Ballerina SLAlpha5 Installed
+  Ballerina Swan Lake Alpha 5 is required.
 
 * Shared Access Signature (SAS) Authentication Credentials
     * Connection String

--- a/asb-ballerina/Package.md
+++ b/asb-ballerina/Package.md
@@ -126,14 +126,14 @@ You can now make an Azure service bus client using the connection configuration.
 ### Step 4: Create a Queue Sender using the Azure service bus client
 You can now make a sender connection using the Azure service bus client. Provide the `queueName` as a parameter.
 ```ballerina
-    checkpanic asbClient->createQueueSender(queueName);
+    handle queueSender = checkpanic asbClient->createQueueSender(queueName);
 ```
 
 ### Step 5 : Create a Queue Receiver using the Azure service bus client
 You can now make a receiver connection using the connection configuration. Provide the `queueName` as a parameter. 
 Optionally you can provide the receive mode which is PEEKLOCK by default.
 ```ballerina
-    checkpanic asbClient->createQueueReceiver(queueName, asb:RECEIVEANDDELETE);
+    handle queueReceiver = checkpanic asbClient->createQueueReceiver(queueName, asb:RECEIVEANDDELETE);
 ```
 
 ### Step 6: Initialize the Input Values
@@ -162,13 +162,13 @@ Initialize the message to be sent with message body, optional parameters and pro
 You can now send a message to the configured azure service bus entity with message body, optional parameters and 
 properties. Here we have shown how to send a text message parsed to the byte array format.
 ```ballerina
-    checkpanic asbClient->send(message1);
+    checkpanic asbClient->send(queueSender, message1);
 ```
 
 ### Step 8: Receive a Message from Azure Service Bus
 You can now receive a message from the configured azure service bus entity.
 ```ballerina
-    asb:Message|asb:Error? messageReceived = asbClient->receive(serverWaitTime);
+    asb:Message|asb:Error? messageReceived = asbClient->receive(queueReceiver, serverWaitTime);
 
     if (messageReceived is asb:Message) {
         log:printInfo("Reading Received Message : " + messageReceived.toString());
@@ -182,13 +182,13 @@ You can now receive a message from the configured azure service bus entity.
 ### Step 9: Close Sender Connection
 You can now close the sender connection.
 ```ballerina
-    checkpanic asbClient->closeSender();
+    checkpanic asbClient->closeSender(queueSender);
 ```
 
 ### Step 10: Close Receiver Connection
 You can now close the receiver connection.
 ```ballerina
-    checkpanic asbClient->closeReceiver();
+    checkpanic asbClient->closeReceiver(queueReceiver);
 ```
 
 Sample is available at:
@@ -222,7 +222,7 @@ You can now make an Azure service bus client using the connection configuration.
 ### Step 4: Create a Queue Sender using the Azure service bus client
 You can now make a sender connection using the Azure service bus client. Provide the `queueName` as a parameter.
 ```ballerina
-    checkpanic asbClient->createQueueSender(queueName);
+    handle queueSender = checkpanic asbClient->createQueueSender(queueName);
 ```
 
 ### Step 5: Initialize the Input Values
@@ -251,19 +251,19 @@ Initialize the message to be sent with message body, optional parameters and pro
 You can now send a message to the configured azure service bus entity with message body, optional parameters and 
 properties. Here we have shown how to send a text message parsed to the byte array format.
 ```ballerina
-    checkpanic asbClient->send(message1);
+    checkpanic asbClient->send(queueSender, message1);
 ```
 
 ### Step 7: Create a service object with the service configuration and the service logic to execute based on the message received
 You can now create a service object with the service configuration specified using the @asb:ServiceConfig annotation. 
-We need to give the connection string and the entity path of the queue we are to listen messages from. Then we can give 
-the service logic to execute when a message is received inside the onMessage remote function.
+We need to give the connection string and the entity path of the queue we are to listen messages from. We can optionally provide the receive mode. Default mode is the PEEKLOCK mode. Then we can give the service logic to execute when a message is received inside the onMessage remote function.
 ```ballerina
     asb:Service asyncTestService =
     @asb:ServiceConfig {
         entityConfig: {
             connectionString: <CONNECTION_STRING>,
-            entityPath: <ENTITY_PATH>
+            entityPath: <ENTITY_PATH>,
+            receiveMode: <PEEKLOCK_OR_RECEIVEONDELETE>
         }
     }
     service object {
@@ -298,10 +298,7 @@ the connection with the Azure Service Bus.
 ### Step 8: Close Sender Connection
 You can now close the sender connection.
 ```ballerina
-    if (senderConnection is asb:SenderConnection) {
-       log:printInfo("Closing Asb sender connection.");
-       checkpanic senderConnection.closeSenderConnection();
-    }
+    checkpanic asbClient->closeSender(queueSender);
 ```
 
 Sample is available at:
@@ -325,7 +322,7 @@ import ballerinax/asb;
 
 // Connection Configurations
 configurable string connectionString = ?;
-configurable string queuePath = ?;
+configurable string queueName = ?;
 
 public function main() {
 
@@ -365,16 +362,17 @@ public function main() {
     asb:AsbClient asbClient = new (config);
 
     log:printInfo("Creating Asb sender connection.");
-    checkpanic asbClient->createQueueSender(queuePath);
+    handle queueSender = checkpanic asbClient->createQueueSender(queueName);
 
     log:printInfo("Creating Asb receiver connection.");
-    checkpanic asbClient->createQueueReceiver(queuePath, asb:RECEIVEANDDELETE);
+    handle queueReceiver = checkpanic asbClient->createQueueReceiver(queueName, asb:RECEIVEANDDELETE);
 
     log:printInfo("Sending via Asb sender connection.");
-    checkpanic asbClient->sendBatch(messages);
+    checkpanic asbClient->sendBatch(queueSender, messages);
 
     log:printInfo("Receiving from Asb receiver connection.");
-    asb:MessageBatch|asb:Error? messageReceived = asbClient->receiveBatch(maxMessageCount, serverWaitTime);
+    asb:MessageBatch|asb:Error? messageReceived = 
+        asbClient->receiveBatch(queueReceiver, maxMessageCount, serverWaitTime);
 
     if (messageReceived is asb:MessageBatch) {
         foreach asb:Message message in messageReceived.messages {
@@ -389,10 +387,10 @@ public function main() {
     }
 
     log:printInfo("Closing Asb sender connection.");
-    checkpanic asbClient->closeSender();
+    checkpanic asbClient->closeSender(queueSender);
 
     log:printInfo("Closing Asb receiver connection.");
-    checkpanic asbClient->closeReceiver();
+    checkpanic asbClient->closeReceiver(queueReceiver);
 }    
 ```
 
@@ -411,8 +409,8 @@ import ballerinax/asb;
 
 // Connection Configurations
 configurable string connectionString = ?;
-configurable string topicPath = ?;
-configurable string subscriptionPath1 = ?;
+configurable string topicName = ?;
+configurable string subscriptionName1 = ?;
 
 public function main() {
 
@@ -441,16 +439,17 @@ public function main() {
     asb:AsbClient asbClient = new (config);
 
     log:printInfo("Creating Asb sender connection.");
-    checkpanic asbClient->createTopicSender(topicPath);
+    handle topicSender = checkpanic asbClient->createTopicSender(topicName);
 
     log:printInfo("Creating Asb receiver connection.");
-    checkpanic asbClient->createSubscriptionReceiver(subscriptionPath1, asb:RECEIVEANDDELETE);
+    handle subscriptionReceiver = 
+        checkpanic asbClient->createSubscriptionReceiver(topicName, subscriptionName1, asb:RECEIVEANDDELETE);
 
     log:printInfo("Sending via Asb sender connection.");
-    checkpanic asbClient->send(message1);
+    checkpanic asbClient->send(topicSender, message1);
 
     log:printInfo("Receiving from Asb receiver connection.");
-    asb:Message|asb:Error? messageReceived = asbClient->receive(serverWaitTime);
+    asb:Message|asb:Error? messageReceived = asbClient->receive(subscriptionReceiver, serverWaitTime);
 
     if (messageReceived is asb:Message) {
         log:printInfo("Reading Received Message : " + messageReceived.toString());
@@ -461,10 +460,10 @@ public function main() {
     }
 
     log:printInfo("Closing Asb sender connection.");
-    checkpanic asbClient->closeSender();
+    checkpanic asbClient->closeSender(topicSender);
 
     log:printInfo("Closing Asb receiver connection.");
-    checkpanic asbClient->closeReceiver();
+    checkpanic asbClient->closeReceiver(subscriptionReceiver);
 }    
 ```
 

--- a/asb-ballerina/Package.md
+++ b/asb-ballerina/Package.md
@@ -13,7 +13,7 @@ basic operations. These APIs use SAS authentication and this module supports SAS
 # Compatibility
 |                     |    Version                  |
 |:-------------------:|:---------------------------:|
-| Ballerina Language  | Swan-Lake-Alpha4            |
+| Ballerina Language  | Swan-Lake-Alpha5            |
 | Service Bus API     | v3.5.1                      |
 
 # Supported Operations
@@ -56,8 +56,8 @@ immediate stop listening.
 * Java 11 Installed
   Java Development Kit (JDK) with version 11 is required.
 
-* Ballerina SLAlpha4 Installed
-  Ballerina Swan Lake Alpha 4 is required.
+* Ballerina SLAlpha5 Installed
+  Ballerina Swan Lake Alpha 5 is required.
 
 * Shared Access Signature (SAS) Authentication Credentials
     * Connection String

--- a/asb-ballerina/client.bal
+++ b/asb-ballerina/client.bal
@@ -252,6 +252,7 @@ public client class AsbClient {
     # Defer the message in a Queue or Subscription based on messageLockToken.  It prevents the message from being 
     # directly received from the queue by setting it aside such that it must be received by sequence number.
     # 
+    # + message - Message record
     # + return - An `asb:Error` if failed to defer message or else sequence number
     @display {label: "Defer Message"}
     isolated remote function defer(@display {label: "Message record"} Message message) 

--- a/asb-ballerina/client.bal
+++ b/asb-ballerina/client.bal
@@ -301,6 +301,7 @@ public client class AsbClient {
     # The operation renews lock on a message in a queue or subscription based on messageLockToken.
     # 
     # + asbReceiver - Asb Receiver
+    # + message - Message record
     # + return - An `asb:Error` if failed to renew message or else `()`
     @display {label: "Renew Lock on Message"}
     isolated remote function renewLock(@display {label: "Asb Receiver"} handle asbReceiver,

--- a/asb-ballerina/commons.bal
+++ b/asb-ballerina/commons.bal
@@ -63,9 +63,11 @@ public type AsbConnectionConfiguration record {|
 #                      Endpoint=sb://namespace_DNS_Name;EntityPath=EVENT_HUB_NAME;
 #                      SharedAccessSignatureToken=SHARED_ACCESS_SIGNATURE_TOKEN
 # + entityPath - Entitypath to the message broker resource
+# + receiveMode - Message receive modes
 public type EntityConfiguration record {|
     string connectionString;
     string entityPath;
+    string receiveMode?;
 |};
 
 # Service configurations used to create a `asb:Connection`.

--- a/asb-ballerina/listener.bal
+++ b/asb-ballerina/listener.bal
@@ -65,6 +65,136 @@ public class Listener {
     public isolated function immediateStop() returns error? {
         return abortConnection(self);
     }
+
+    # Complete message from queue or subscription based on messageLockToken. Declares the message processing to be 
+    # successfully completed, removing the message from the queue.
+    # 
+    # + message - Message record
+    # + return - An `asb:Error` if failed to complete message or else `()`
+    @display {label: "Complete Messages"}
+    public isolated function complete(@display {label: "Message record"} Message message) returns error? {
+        handle asbReceiverConnection = check getReceiver(self);
+        if (message?.lockToken.toString() != DEFAULT_MESSAGE_LOCK_TOKEN) {
+            return complete(asbReceiverConnection, message?.lockToken.toString());
+        }
+        return error Error("Failed to complete message with ID " + message?.messageId.toString());
+    }
+
+    # Abandon message from queue or subscription based on messageLockToken. Abandon processing of the message for 
+    # the time being, returning the message immediately back to the queue to be picked up by another (or the same) 
+    # receiver.
+    # 
+    # + message - Message record
+    # + return - An `asb:Error` if failed to abandon message or else `()`
+    @display {label: "Abandon Message"}
+    public isolated function abandon(@display {label: "Message record"} Message message) returns Error? {
+        handle asbReceiverConnection = check getReceiver(self);
+        if (message?.lockToken.toString() != DEFAULT_MESSAGE_LOCK_TOKEN) {
+            return abandon(asbReceiverConnection, message?.lockToken.toString());
+        }
+        return error Error("Failed to abandon message with ID " + message?.messageId.toString());
+    }
+
+    # Dead-Letter the message & moves the message to the Dead-Letter Queue based on messageLockToken. Transfer 
+    # the message from the primary queue into a special "dead-letter sub-queue".
+    # 
+    # + message - Message record
+    # + deadLetterReason - The deadletter reason.
+    # + deadLetterErrorDescription - The deadletter error description.
+    # + return - An `asb:Error` if failed to deadletter message or else `()`
+    @display {label: "Dead Letter Message"}
+    public isolated function deadLetter(@display {label: "Message record"} Message message, 
+                                        @display {label: "Dead letter reason (optional)"} string? deadLetterReason = (), 
+                                        @display{label: "Dead letter description (optional)"} 
+                                        string? deadLetterErrorDescription = ()) returns Error? {
+        handle asbReceiverConnection = check getReceiver(self);
+        if (message?.lockToken.toString() != DEFAULT_MESSAGE_LOCK_TOKEN) {
+            return deadLetter(asbReceiverConnection, message?.lockToken.toString(), deadLetterReason, 
+                deadLetterErrorDescription);
+        }
+        return error Error("Failed to deadletter message with ID " + message?.messageId.toString());
+    }
+
+    # Defer the message in a Queue or Subscription based on messageLockToken.  It prevents the message from being 
+    # directly received from the queue by setting it aside such that it must be received by sequence number.
+    # 
+    # + message - Message record
+    # + return - An `asb:Error` if failed to defer message or else sequence number
+    @display {label: "Defer Message"}
+    public isolated function defer(@display {label: "Message record"} Message message) 
+                                   returns @display {label: "Sequence Number of the deferred message"} int|Error {
+        handle asbReceiverConnection = check getReceiver(self);
+        _ = check defer(asbReceiverConnection, message?.lockToken.toString());
+        return <int> message?.sequenceNumber;
+    }
+
+    # Receives a deferred Message. Deferred messages can only be received by using sequence number and return
+    # Message object.
+    # 
+    # + sequenceNumber - Unique number assigned to a message by Service Bus. The sequence number is a unique 64-bit
+    #                    integer assigned to a message as it is accepted and stored by the broker and functions as
+    #                    its true identifier.
+    # + return - An `asb:Error` if failed to receive deferred message, a Message record if successful or else `()`
+    @display {label: "Receive Deferred Message"}
+    public isolated function receiveDeferred(@display {label: "Sequence Number of the deferred message"} 
+                                             int sequenceNumber) 
+                                             returns @display {label: "Deferred Message record"}  Message|Error? {
+        handle asbReceiverConnection = check getReceiver(self);
+        Message|() message = check receiveDeferred(asbReceiverConnection, sequenceNumber);
+        if (message is Message) {
+            _ = check self.mapContentType(message);
+            return message;
+        }
+        return; 
+    }
+
+    # The operation renews lock on a message in a queue or subscription based on messageLockToken.
+    # 
+    # + message - Message record
+    # + return - An `asb:Error` if failed to renew message or else `()`
+    @display {label: "Renew Lock on Message"}
+    public isolated function renewLock(@display {label: "Message record"} Message message) returns Error? {
+        handle asbReceiverConnection = check getReceiver(self);
+        if (message?.lockToken.toString() != DEFAULT_MESSAGE_LOCK_TOKEN) {
+            return renewLock(asbReceiverConnection, message?.lockToken.toString());
+        }
+        return error Error("Failed to renew lock on message with ID " + message?.messageId.toString());
+    }
+
+    # Set the prefetch count of the receiver.
+    # Prefetch speeds up the message flow by aiming to have a message readily available for local retrieval when and
+    # before the application asks for one using Receive. Setting a non-zero value prefetches PrefetchCount
+    # number of messages. Setting the value to zero turns prefetch off. For both PEEKLOCK mode and
+    # RECEIVEANDDELETE mode, the default value is 0.
+    # 
+    # + prefetchCount - The desired prefetch count.
+    # + return - An `asb:Error` if failed to renew message or else `()`
+    @display {label: "Set Prefetch Count"}
+    public isolated function setPrefetchCount(@display {label: "Prefetch count"} int prefetchCount) returns Error? {
+        handle asbReceiverConnection = check getReceiver(self);
+        return setPrefetchCount(asbReceiverConnection, prefetchCount);
+    }
+
+    isolated function mapContentType(Message message) returns Error? {
+        match message?.contentType {
+            TEXT => {
+                message.body = check nativeGetTextContent(<byte[]> message.body);
+            }
+            JSON => {
+                message.body = check nativeGetJSONContent(<byte[]> message.body);
+            }
+            XML => {
+                message.body = check nativeGetXMLContent(<byte[]> message.body);
+            }
+            BYTE_ARRAY => {
+                message.body = <byte[]> message.body;
+            }
+            _ => {
+                message.body = message.body.toString();
+            }
+        }
+        return; 
+    }
 }  
 
 # The ASB service type
@@ -99,6 +229,11 @@ isolated function stop(Listener lis) returns Error? =
 } external;
 
 isolated function abortConnection(Listener lis) returns Error? =
+@java:Method {
+    'class: "org.ballerinalang.asb.connection.ListenerUtils"
+} external;
+
+isolated function getReceiver(Listener lis) returns handle|Error =
 @java:Method {
     'class: "org.ballerinalang.asb.connection.ListenerUtils"
 } external;

--- a/asb-ballerina/samples/README.md
+++ b/asb-ballerina/samples/README.md
@@ -14,7 +14,7 @@ import ballerinax/asb;
 
 // Connection Configurations
 configurable string connectionString = ?;
-configurable string queuePath = ?;
+configurable string queueName = ?;
 
 public function main() {
 
@@ -43,16 +43,16 @@ public function main() {
     asb:AsbClient asbClient = new (config);
 
     log:printInfo("Creating Asb sender connection.");
-    checkpanic asbClient->createQueueSender(queuePath);
+    handle queueSender = checkpanic asbClient->createQueueSender(queueName);
 
     log:printInfo("Creating Asb receiver connection.");
-    checkpanic asbClient->createQueueReceiver(queuePath, asb:RECEIVEANDDELETE);
+    handle queueReceiver = checkpanic asbClient->createQueueReceiver(queueName, asb:RECEIVEANDDELETE);
 
     log:printInfo("Sending via Asb sender connection.");
-    checkpanic asbClient->send(message1);
+    checkpanic asbClient->send(queueSender, message1);
 
     log:printInfo("Receiving from Asb receiver connection.");
-    asb:Message|asb:Error? messageReceived = asbClient->receive(serverWaitTime);
+    asb:Message|asb:Error? messageReceived = asbClient->receive(queueReceiver, serverWaitTime);
 
     if (messageReceived is asb:Message) {
         log:printInfo("Reading Received Message : " + messageReceived.toString());
@@ -63,10 +63,10 @@ public function main() {
     }
 
     log:printInfo("Closing Asb sender connection.");
-    checkpanic asbClient->closeSender();
+    checkpanic asbClient->closeSender(queueSender);
 
     log:printInfo("Closing Asb receiver connection.");
-    checkpanic asbClient->closeReceiver();
+    checkpanic asbClient->closeReceiver(queueReceiver);
 }    
 ```
 
@@ -84,7 +84,8 @@ import ballerinax/asb;
 
 // Connection Configurations
 configurable string connectionString = ?;
-configurable string queuePath = ?;
+configurable string topicName = ?;
+configurable string subscriptionName1 = ?;
 
 public function main() {
 
@@ -124,16 +125,18 @@ public function main() {
     asb:AsbClient asbClient = new (config);
 
     log:printInfo("Creating Asb sender connection.");
-    checkpanic asbClient->createQueueSender(queuePath);
+    handle topicSender = checkpanic asbClient->createTopicSender(topicName);
 
     log:printInfo("Creating Asb receiver connection.");
-    checkpanic asbClient->createQueueReceiver(queuePath, asb:RECEIVEANDDELETE);
+    handle subscriptionReceiver = 
+        checkpanic asbClient->createSubscriptionReceiver(topicName, subscriptionName1, asb:RECEIVEANDDELETE);
 
     log:printInfo("Sending via Asb sender connection.");
-    checkpanic asbClient->sendBatch(messages);
+    checkpanic asbClient->sendBatch(topicSender, messages);
 
     log:printInfo("Receiving from Asb receiver connection.");
-    asb:MessageBatch|asb:Error? messageReceived = asbClient->receiveBatch(maxMessageCount, serverWaitTime);
+    asb:MessageBatch|asb:Error? messageReceived = 
+        asbClient->receiveBatch(subscriptionReceiver, maxMessageCount, serverWaitTime);
 
     if (messageReceived is asb:MessageBatch) {
         foreach asb:Message message in messageReceived.messages {
@@ -142,16 +145,16 @@ public function main() {
             }
         }
     } else if (messageReceived is ()) {
-        log:printError("No message in the queue.");
+        log:printError("No message in the subscription.");
     } else {
         log:printError("Receiving message via Asb receiver connection failed.");
     }
 
     log:printInfo("Closing Asb sender connection.");
-    checkpanic asbClient->closeSender();
+    checkpanic asbClient->closeSender(topicSender);
 
     log:printInfo("Closing Asb receiver connection.");
-    checkpanic asbClient->closeReceiver();
+    checkpanic asbClient->closeReceiver(subscriptionReceiver);
 }    
 ```
 
@@ -169,8 +172,8 @@ import ballerinax/asb;
 
 // Connection Configurations
 configurable string connectionString = ?;
-configurable string topicPath = ?;
-configurable string subscriptionPath1 = ?;
+configurable string topicName = ?;
+configurable string subscriptionName1 = ?;
 
 public function main() {
 
@@ -199,16 +202,17 @@ public function main() {
     asb:AsbClient asbClient = new (config);
 
     log:printInfo("Creating Asb sender connection.");
-    checkpanic asbClient->createTopicSender(topicPath);
+    handle topicSender = checkpanic asbClient->createTopicSender(topicName);
 
     log:printInfo("Creating Asb receiver connection.");
-    checkpanic asbClient->createSubscriptionReceiver(subscriptionPath1, asb:RECEIVEANDDELETE);
+    handle subscriptionReceiver = 
+        checkpanic asbClient->createSubscriptionReceiver(topicName, subscriptionName1, asb:RECEIVEANDDELETE);
 
     log:printInfo("Sending via Asb sender connection.");
-    checkpanic asbClient->send(message1);
+    checkpanic asbClient->send(topicSender, message1);
 
     log:printInfo("Receiving from Asb receiver connection.");
-    asb:Message|asb:Error? messageReceived = asbClient->receive(serverWaitTime);
+    asb:Message|asb:Error? messageReceived = asbClient->receive(subscriptionReceiver, serverWaitTime);
 
     if (messageReceived is asb:Message) {
         log:printInfo("Reading Received Message : " + messageReceived.toString());
@@ -219,10 +223,10 @@ public function main() {
     }
 
     log:printInfo("Closing Asb sender connection.");
-    checkpanic asbClient->closeSender();
+    checkpanic asbClient->closeSender(topicSender);
 
     log:printInfo("Closing Asb receiver connection.");
-    checkpanic asbClient->closeReceiver();
+    checkpanic asbClient->closeReceiver(subscriptionReceiver);
 }    
 ```
 
@@ -241,8 +245,8 @@ import ballerinax/asb;
 
 // Connection Configurations
 configurable string connectionString = ?;
-configurable string topicPath = ?;
-configurable string subscriptionPath1 = ?;
+configurable string topicName = ?;
+configurable string subscriptionName1 = ?;
 
 public function main() {
 
@@ -282,16 +286,18 @@ public function main() {
     asb:AsbClient asbClient = new (config);
 
     log:printInfo("Creating Asb sender connection.");
-    checkpanic asbClient->createTopicSender(topicPath);
+    handle topicSender = checkpanic asbClient->createTopicSender(topicName);
 
     log:printInfo("Creating Asb receiver connection.");
-    checkpanic asbClient->createSubscriptionReceiver(subscriptionPath1, asb:RECEIVEANDDELETE);
+    handle subscriptionReceiver = 
+        checkpanic asbClient->createSubscriptionReceiver(topicName, subscriptionName1, asb:RECEIVEANDDELETE);
 
     log:printInfo("Sending via Asb sender connection.");
-    checkpanic asbClient->sendBatch(messages);
+    checkpanic asbClient->sendBatch(topicSender, messages);
 
     log:printInfo("Receiving from Asb receiver connection.");
-    asb:MessageBatch|asb:Error? messageReceived = asbClient->receiveBatch(maxMessageCount, serverWaitTime);
+    asb:MessageBatch|asb:Error? messageReceived = 
+        asbClient->receiveBatch(subscriptionReceiver, maxMessageCount, serverWaitTime);
 
     if (messageReceived is asb:MessageBatch) {
         foreach asb:Message message in messageReceived.messages {
@@ -306,10 +312,10 @@ public function main() {
     }
 
     log:printInfo("Closing Asb sender connection.");
-    checkpanic asbClient->closeSender();
+    checkpanic asbClient->closeSender(topicSender);
 
     log:printInfo("Closing Asb receiver connection.");
-    checkpanic asbClient->closeReceiver();
+    checkpanic asbClient->closeReceiver(subscriptionReceiver);
 }    
 ```
 
@@ -327,7 +333,7 @@ import ballerinax/asb;
 
 // Connection Configurations
 configurable string connectionString = ?;
-configurable string queuePath = ?;
+configurable string queueName = ?;
 
 public function main() {
 
@@ -356,19 +362,19 @@ public function main() {
     asb:AsbClient asbClient = new (config);
 
     log:printInfo("Creating Asb sender connection.");
-    checkpanic asbClient->createQueueSender(queuePath);
+    handle queueSender = checkpanic asbClient->createQueueSender(queueName);
 
     log:printInfo("Creating Asb receiver connection.");
-    checkpanic asbClient->createQueueReceiver(queuePath, asb:PEEKLOCK);
+    handle queueReceiver = checkpanic asbClient->createQueueReceiver(queueName, asb:PEEKLOCK);
 
     log:printInfo("Sending via Asb sender connection.");
-    checkpanic asbClient->send(message1);
+    checkpanic asbClient->send(queueSender, message1);
 
     log:printInfo("Receiving from Asb receiver connection.");
-    asb:Message|asb:Error? messageReceived = asbClient->receive(serverWaitTime);
+    asb:Message|asb:Error? messageReceived = asbClient->receive(queueReceiver, serverWaitTime);
 
     if (messageReceived is asb:Message) {
-        checkpanic asbClient->complete(messageReceived);
+        checkpanic asbClient->complete(queueReceiver, messageReceived);
         log:printInfo("Complete message successful");
     } else if (messageReceived is ()) {
         log:printError("No message in the queue.");
@@ -377,10 +383,10 @@ public function main() {
     }
 
     log:printInfo("Closing Asb sender connection.");
-    checkpanic asbClient->closeSender();
+    checkpanic asbClient->closeSender(queueSender);
 
     log:printInfo("Closing Asb receiver connection.");
-    checkpanic asbClient->closeReceiver();
+    checkpanic asbClient->closeReceiver(queueReceiver);
 }    
 ```
 
@@ -398,8 +404,8 @@ import ballerinax/asb;
 
 // Connection Configurations
 configurable string connectionString = ?;
-configurable string topicPath = ?;
-configurable string subscriptionPath1 = ?;
+configurable string topicName = ?;
+configurable string subscriptionName1 = ?;
 
 public function main() {
 
@@ -428,19 +434,20 @@ public function main() {
     asb:AsbClient asbClient = new (config);
 
     log:printInfo("Creating Asb sender connection.");
-    checkpanic asbClient->createTopicSender(topicPath);
+    handle topicSender = checkpanic asbClient->createTopicSender(topicName);
 
     log:printInfo("Creating Asb receiver connection.");
-    checkpanic asbClient->createSubscriptionReceiver(subscriptionPath1, asb:PEEKLOCK);
+    handle subscriptionReceiver = 
+        checkpanic asbClient->createSubscriptionReceiver(topicName, subscriptionName1, asb:PEEKLOCK);
 
     log:printInfo("Sending via Asb sender connection.");
-    checkpanic asbClient->send(message1);
+    checkpanic asbClient->send(topicSender, message1);
 
     log:printInfo("Receiving from Asb receiver connection.");
-    asb:Message|asb:Error? messageReceived = asbClient->receive(serverWaitTime);
+    asb:Message|asb:Error? messageReceived = asbClient->receive(subscriptionReceiver, serverWaitTime);
 
     if (messageReceived is asb:Message) {
-        checkpanic asbClient->complete(messageReceived);
+        checkpanic asbClient->complete(subscriptionReceiver, messageReceived);
         log:printInfo("Complete message successful");
     } else if (messageReceived is ()) {
         log:printError("No message in the subscription.");
@@ -449,10 +456,10 @@ public function main() {
     }
 
     log:printInfo("Closing Asb sender connection.");
-    checkpanic asbClient->closeSender();
+    checkpanic asbClient->closeSender(topicSender);
 
     log:printInfo("Closing Asb receiver connection.");
-    checkpanic asbClient->closeReceiver();
+    checkpanic asbClient->closeReceiver(subscriptionReceiver);
 }    
 ```
 
@@ -471,7 +478,7 @@ import ballerinax/asb;
 
 // Connection Configurations
 configurable string connectionString = ?;
-configurable string queuePath = ?;
+configurable string queueName = ?;
 
 public function main() {
 
@@ -500,22 +507,22 @@ public function main() {
     asb:AsbClient asbClient = new (config);
 
     log:printInfo("Creating Asb sender connection.");
-    checkpanic asbClient->createQueueSender(queuePath);
+    handle queueSender = checkpanic asbClient->createQueueSender(queueName);
 
     log:printInfo("Creating Asb receiver connection.");
-    checkpanic asbClient->createQueueReceiver(queuePath, asb:PEEKLOCK);
+    handle queueReceiver = checkpanic asbClient->createQueueReceiver(queueName, asb:PEEKLOCK);
 
     log:printInfo("Sending via Asb sender connection.");
-    checkpanic asbClient->send(message1);
+    checkpanic asbClient->send(queueSender, message1);
 
     log:printInfo("Receiving from Asb receiver connection.");
-    asb:Message|asb:Error? messageReceived = asbClient->receive(serverWaitTime);
+    asb:Message|asb:Error? messageReceived = asbClient->receive(queueReceiver, serverWaitTime);
 
     if (messageReceived is asb:Message) {
-        checkpanic asbClient->abandon(messageReceived);
-        asb:Message|asb:Error? messageReceivedAgain = asbClient->receive(serverWaitTime);
+        checkpanic asbClient->abandon(queueReceiver, messageReceived);
+        asb:Message|asb:Error? messageReceivedAgain = asbClient->receive(queueReceiver, serverWaitTime);
         if (messageReceivedAgain is asb:Message) {
-            checkpanic asbClient->complete(messageReceivedAgain);
+            checkpanic asbClient->complete(queueReceiver, messageReceivedAgain);
             log:printInfo("Abandon message successful");
         } else {
             log:printError("Abandon message not succesful.");
@@ -527,10 +534,10 @@ public function main() {
     }
 
     log:printInfo("Closing Asb sender connection.");
-    checkpanic asbClient->closeSender();
+    checkpanic asbClient->closeSender(queueSender);
 
     log:printInfo("Closing Asb receiver connection.");
-    checkpanic asbClient->closeReceiver();
+    checkpanic asbClient->closeReceiver(queueReceiver);
 }    
 ```
 
@@ -549,8 +556,8 @@ import ballerinax/asb;
 
 // Connection Configurations
 configurable string connectionString = ?;
-configurable string topicPath = ?;
-configurable string subscriptionPath1 = ?;
+configurable string topicName = ?;
+configurable string subscriptionName1 = ?;
 
 public function main() {
 
@@ -579,22 +586,23 @@ public function main() {
     asb:AsbClient asbClient = new (config);
 
     log:printInfo("Creating Asb sender connection.");
-    checkpanic asbClient->createTopicSender(topicPath);
+    handle topicSender = checkpanic asbClient->createTopicSender(topicName);
 
     log:printInfo("Creating Asb receiver connection.");
-    checkpanic asbClient->createSubscriptionReceiver(subscriptionPath1, asb:PEEKLOCK);
+    handle subscriptionReceiver = 
+        checkpanic asbClient->createSubscriptionReceiver(topicName, subscriptionName1, asb:PEEKLOCK);
 
     log:printInfo("Sending via Asb sender connection.");
-    checkpanic asbClient->send(message1);
+    checkpanic asbClient->send(topicSender, message1);
 
     log:printInfo("Receiving from Asb receiver connection.");
-    asb:Message|asb:Error? messageReceived = asbClient->receive(serverWaitTime);
+    asb:Message|asb:Error? messageReceived = asbClient->receive(subscriptionReceiver, serverWaitTime);
 
     if (messageReceived is asb:Message) {
-        checkpanic asbClient->abandon(messageReceived);
-        asb:Message|asb:Error? messageReceivedAgain = asbClient->receive(serverWaitTime);
+        checkpanic asbClient->abandon(subscriptionReceiver, messageReceived);
+        asb:Message|asb:Error? messageReceivedAgain = asbClient->receive(subscriptionReceiver, serverWaitTime);
         if (messageReceivedAgain is asb:Message) {
-            checkpanic asbClient->complete(messageReceivedAgain);
+            checkpanic asbClient->complete(subscriptionReceiver, messageReceivedAgain);
             log:printInfo("Abandon message successful");
         } else {
             log:printError("Abandon message not succesful.");
@@ -606,10 +614,10 @@ public function main() {
     }
 
     log:printInfo("Closing Asb sender connection.");
-    checkpanic asbClient->closeSender();
+    checkpanic asbClient->closeSender(topicSender);
 
     log:printInfo("Closing Asb receiver connection.");
-    checkpanic asbClient->closeReceiver();
+    checkpanic asbClient->closeReceiver(subscriptionReceiver);
 }    
 ```
 
@@ -630,7 +638,7 @@ import ballerinax/asb;
 
 // Connection Configurations
 configurable string connectionString = ?;
-configurable string queuePath = ?;
+configurable string queueName = ?;
 
 public function main() {
 
@@ -658,16 +666,16 @@ public function main() {
     asb:AsbClient asbClient = new (config);
 
     log:printInfo("Creating Asb sender connection.");
-    checkpanic asbClient->createQueueSender(queuePath);
+    handle queueSender = checkpanic asbClient->createQueueSender(queueName);
 
     log:printInfo("Sending via Asb sender connection.");
-    checkpanic asbClient->send(message1);
+    checkpanic asbClient->send(queueSender, message1);
 
     asb:Service asyncTestService =
     @asb:ServiceConfig {
         entityConfig: {
             connectionString: connectionString,
-            entityPath: queuePath
+            entityPath: queueName
         }
     }
     service object {
@@ -690,7 +698,7 @@ public function main() {
     }
 
     log:printInfo("Closing Asb sender connection.");
-    checkpanic asbClient->closeSender();
+    checkpanic asbClient->closeSender(queueSender);
 }    
 ```
 
@@ -709,7 +717,7 @@ import ballerinax/asb;
 
 // Connection Configurations
 configurable string connectionString = ?;
-configurable string queuePath = ?;
+configurable string queueName = ?;
 
 public function main() {
 
@@ -738,20 +746,20 @@ public function main() {
     asb:AsbClient asbClient = new (config);
 
     log:printInfo("Creating Asb sender connection.");
-    checkpanic asbClient->createQueueSender(queuePath);
+    handle queueSender = checkpanic asbClient->createQueueSender(queueName);
 
     log:printInfo("Creating Asb receiver connection.");
-    checkpanic asbClient->createQueueReceiver(queuePath, asb:PEEKLOCK);
+    handle queueReceiver = checkpanic asbClient->createQueueReceiver(queueName, asb:PEEKLOCK);
 
     log:printInfo("Sending via Asb sender connection.");
-    checkpanic asbClient->send(message1);
+    checkpanic asbClient->send(queueSender, message1);
 
     log:printInfo("Receiving from Asb receiver connection.");
-    asb:Message|asb:Error? messageReceived = asbClient->receive(serverWaitTime);
+    asb:Message|asb:Error? messageReceived = asbClient->receive(queueReceiver, serverWaitTime);
 
     if (messageReceived is asb:Message) {
-        checkpanic asbClient->deadLetter(messageReceived);
-        asb:Message|asb:Error? messageReceivedAgain = asbClient->receive(serverWaitTime);
+        checkpanic asbClient->deadLetter(queueReceiver, messageReceived);
+        asb:Message|asb:Error? messageReceivedAgain = asbClient->receive(queueReceiver, serverWaitTime);
         if (messageReceivedAgain is ()) {
             log:printInfo("Deadletter message successful");
         } else {
@@ -764,10 +772,10 @@ public function main() {
     }
 
     log:printInfo("Closing Asb sender connection.");
-    checkpanic asbClient->closeSender();
+    checkpanic asbClient->closeSender(queueSender);
 
     log:printInfo("Closing Asb receiver connection.");
-    checkpanic asbClient->closeReceiver();
+    checkpanic asbClient->closeReceiver(queueReceiver);
 }    
 ```
 
@@ -786,8 +794,8 @@ import ballerinax/asb;
 
 // Connection Configurations
 configurable string connectionString = ?;
-configurable string topicPath = ?;
-configurable string subscriptionPath1 = ?;
+configurable string topicName = ?;
+configurable string subscriptionName1 = ?;
 
 public function main() {
 
@@ -816,20 +824,21 @@ public function main() {
     asb:AsbClient asbClient = new (config);
 
     log:printInfo("Creating Asb sender connection.");
-    checkpanic asbClient->createTopicSender(topicPath);
+    handle topicSender = checkpanic asbClient->createTopicSender(topicName);
 
     log:printInfo("Creating Asb receiver connection.");
-    checkpanic asbClient->createSubscriptionReceiver(subscriptionPath1, asb:PEEKLOCK);
+    handle subscriptionReceiver = 
+        checkpanic asbClient->createSubscriptionReceiver(topicName, subscriptionName1, asb:PEEKLOCK);
 
     log:printInfo("Sending via Asb sender connection.");
-    checkpanic asbClient->send(message1);
+    checkpanic asbClient->send(topicSender, message1);
 
     log:printInfo("Receiving from Asb receiver connection.");
-    asb:Message|asb:Error? messageReceived = asbClient->receive(serverWaitTime);
+    asb:Message|asb:Error? messageReceived = asbClient->receive(subscriptionReceiver, serverWaitTime);
 
     if (messageReceived is asb:Message) {
-        checkpanic asbClient->deadLetter(messageReceived);
-        asb:Message|asb:Error? messageReceivedAgain = asbClient->receive(serverWaitTime);
+        checkpanic asbClient->deadLetter(subscriptionReceiver, messageReceived);
+        asb:Message|asb:Error? messageReceivedAgain = asbClient->receive(subscriptionReceiver, serverWaitTime);
         if (messageReceivedAgain is ()) {
             log:printInfo("Deadletter message successful");
         } else {
@@ -842,10 +851,10 @@ public function main() {
     }
 
     log:printInfo("Closing Asb sender connection.");
-    checkpanic asbClient->closeSender();
+    checkpanic asbClient->closeSender(topicSender);
 
     log:printInfo("Closing Asb receiver connection.");
-    checkpanic asbClient->closeReceiver();
+    checkpanic asbClient->closeReceiver(subscriptionReceiver);
 }    
 ```
 
@@ -864,7 +873,7 @@ import ballerinax/asb;
 
 // Connection Configurations
 configurable string connectionString = ?;
-configurable string queuePath = ?;
+configurable string queueName = ?;
 
 public function main() {
 
@@ -893,21 +902,22 @@ public function main() {
     asb:AsbClient asbClient = new (config);
 
     log:printInfo("Creating Asb sender connection.");
-    checkpanic asbClient->createQueueSender(queuePath);
+    handle queueSender = checkpanic asbClient->createQueueSender(queueName);
 
     log:printInfo("Creating Asb receiver connection.");
-    checkpanic asbClient->createQueueReceiver(queuePath, asb:PEEKLOCK);
+    handle queueReceiver = checkpanic asbClient->createQueueReceiver(queueName, asb:PEEKLOCK);
 
     log:printInfo("Sending via Asb sender connection.");
-    checkpanic asbClient->send(message1);
+    checkpanic asbClient->send(queueSender, message1);
 
     log:printInfo("Receiving from Asb receiver connection.");
-    asb:Message|asb:Error? messageReceived = asbClient->receive(serverWaitTime);
+    asb:Message|asb:Error? messageReceived = asbClient->receive(queueReceiver, serverWaitTime);
 
     if (messageReceived is asb:Message) {
-        int sequenceNumber = checkpanic asbClient->defer(messageReceived);
+        int sequenceNumber = checkpanic asbClient->defer(queueReceiver, messageReceived);
         log:printInfo("Defer message successful");
-        asb:Message|asb:Error? messageReceivedAgain = checkpanic asbClient->receiveDeferred(sequenceNumber);
+        asb:Message|asb:Error? messageReceivedAgain = 
+            checkpanic asbClient->receiveDeferred(queueReceiver,sequenceNumber);
         if (messageReceivedAgain is asb:Message) {
             log:printInfo("Reading Deferred Message : " + messageReceivedAgain.toString());
         }
@@ -918,10 +928,10 @@ public function main() {
     }
 
     log:printInfo("Closing Asb sender connection.");
-    checkpanic asbClient->closeSender();
+    checkpanic asbClient->closeSender(queueSender);
 
     log:printInfo("Closing Asb receiver connection.");
-    checkpanic asbClient->closeReceiver();
+    checkpanic asbClient->closeReceiver(queueReceiver);
 }    
 ```
 
@@ -940,8 +950,8 @@ import ballerinax/asb;
 
 // Connection Configurations
 configurable string connectionString = ?;
-configurable string topicPath = ?;
-configurable string subscriptionPath1 = ?;
+configurable string topicName = ?;
+configurable string subscriptionName1 = ?;
 
 public function main() {
 
@@ -970,21 +980,23 @@ public function main() {
     asb:AsbClient asbClient = new (config);
 
     log:printInfo("Creating Asb sender connection.");
-    checkpanic asbClient->createTopicSender(topicPath);
+    handle topicSender = checkpanic asbClient->createTopicSender(topicName);
 
     log:printInfo("Creating Asb receiver connection.");
-    checkpanic asbClient->createSubscriptionReceiver(subscriptionPath1, asb:PEEKLOCK);
+    handle subscriptionReceiver = 
+        checkpanic asbClient->createSubscriptionReceiver(topicName, subscriptionName1, asb:PEEKLOCK);
 
     log:printInfo("Sending via Asb sender connection.");
-    checkpanic asbClient->send(message1);
+    checkpanic asbClient->send(topicSender, message1);
 
     log:printInfo("Receiving from Asb receiver connection.");
-    asb:Message|asb:Error? messageReceived = asbClient->receive(serverWaitTime);
+    asb:Message|asb:Error? messageReceived = asbClient->receive(subscriptionReceiver, serverWaitTime);
 
     if (messageReceived is asb:Message) {
-        int sequenceNumber = checkpanic asbClient->defer(messageReceived);
+        int sequenceNumber = checkpanic asbClient->defer(subscriptionReceiver, messageReceived);
         log:printInfo("Defer message successful");
-        asb:Message|asb:Error? messageReceivedAgain = checkpanic asbClient->receiveDeferred(sequenceNumber);
+        asb:Message|asb:Error? messageReceivedAgain = 
+            checkpanic asbClient->receiveDeferred(subscriptionReceiver, sequenceNumber);
         if (messageReceivedAgain is asb:Message) {
             log:printInfo("Reading Deferred Message : " + messageReceivedAgain.toString());
         }
@@ -995,10 +1007,10 @@ public function main() {
     }
 
     log:printInfo("Closing Asb sender connection.");
-    checkpanic asbClient->closeSender();
+    checkpanic asbClient->closeSender(topicSender);
 
     log:printInfo("Closing Asb receiver connection.");
-    checkpanic asbClient->closeReceiver();
+    checkpanic asbClient->closeReceiver(subscriptionReceiver);
 }    
 ```
 
@@ -1017,7 +1029,7 @@ import ballerinax/asb;
 
 // Connection Configurations
 configurable string connectionString = ?;
-configurable string queuePath = ?;
+configurable string queueName = ?;
 
 public function main() {
 
@@ -1046,25 +1058,20 @@ public function main() {
     asb:AsbClient asbClient = new (config);
 
     log:printInfo("Creating Asb sender connection.");
-    checkpanic asbClient->createQueueSender(queuePath);
+    handle queueSender = checkpanic asbClient->createQueueSender(queueName);
 
     log:printInfo("Creating Asb receiver connection.");
-    checkpanic asbClient->createQueueReceiver(queuePath, asb:PEEKLOCK);
+    handle queueReceiver = checkpanic asbClient->createQueueReceiver(queueName, asb:PEEKLOCK);
 
     log:printInfo("Sending via Asb sender connection.");
-    checkpanic asbClient->send(message1);
+    checkpanic asbClient->send(queueSender, message1);
 
     log:printInfo("Receiving from Asb receiver connection.");
-    asb:Message|asb:Error? messageReceived = asbClient->receive(serverWaitTime);
+    asb:Message|asb:Error? messageReceived = asbClient->receive(queueReceiver, serverWaitTime);
 
     if (messageReceived is asb:Message) {
-        checkpanic asbClient->renewLock(messageReceived);
-        asb:Message|asb:Error? messageReceivedAgain = asbClient->receive(serverWaitTime);
-        if (messageReceivedAgain is ()) {
-            log:printInfo("Renew lock message successful");
-        } else {
-            log:printError("Renew lock on message not succesful.");
-        }
+        checkpanic asbClient->renewLock(queueReceiver, messageReceived);
+        log:printInfo("Renew lock message successful");
     } else if (messageReceived is ()) {
         log:printError("No message in the queue.");
     } else {
@@ -1072,10 +1079,10 @@ public function main() {
     }
 
     log:printInfo("Closing Asb sender connection.");
-    checkpanic asbClient->closeSender();
+    checkpanic asbClient->closeSender(queueSender);
 
     log:printInfo("Closing Asb receiver connection.");
-    checkpanic asbClient->closeReceiver();
+    checkpanic asbClient->closeReceiver(queueReceiver);
 }    
 ```
 
@@ -1094,8 +1101,8 @@ import ballerinax/asb;
 
 // Connection Configurations
 configurable string connectionString = ?;
-configurable string topicPath = ?;
-configurable string subscriptionPath1 = ?;
+configurable string topicName = ?;
+configurable string subscriptionName1 = ?;
 
 public function main() {
 
@@ -1124,25 +1131,22 @@ public function main() {
     asb:AsbClient asbClient = new (config);
 
     log:printInfo("Creating Asb sender connection.");
-    checkpanic asbClient->createTopicSender(topicPath);
+    handle topicSender = checkpanic asbClient->createTopicSender(topicName);
 
     log:printInfo("Creating Asb receiver connection.");
-    checkpanic asbClient->createSubscriptionReceiver(subscriptionPath1, asb:PEEKLOCK);
+    handle subscriptionReceiver = 
+        checkpanic asbClient->createSubscriptionReceiver(topicName, subscriptionName1, asb:PEEKLOCK);
     
     log:printInfo("Sending via Asb sender connection.");
-    checkpanic asbClient->send(message1);
+    checkpanic asbClient->send(topicSender, message1);
 
     log:printInfo("Receiving from Asb receiver connection.");
-    asb:Message|asb:Error? messageReceived = asbClient->receive(serverWaitTime);
+    asb:Message|asb:Error? messageReceived = asbClient->receive(subscriptionReceiver, serverWaitTime);
 
     if (messageReceived is asb:Message) {
-        checkpanic asbClient->renewLock(messageReceived);
-        asb:Message|asb:Error? messageReceivedAgain = asbClient->receive(serverWaitTime);
-        if (messageReceivedAgain is ()) {
-            log:printInfo("Renew lock message successful");
-        } else {
-            log:printError("Renew lock on message not succesful.");
-        }
+        checkpanic asbClient->renewLock(subscriptionReceiver, messageReceived);
+        asb:Message|asb:Error? messageReceivedAgain = asbClient->receive(subscriptionReceiver, serverWaitTime);
+        log:printInfo("Renew lock message successful");
     } else if (messageReceived is ()) {
         log:printError("No message in the queue.");
     } else {
@@ -1150,9 +1154,9 @@ public function main() {
     }
 
     log:printInfo("Closing Asb sender connection.");
-    checkpanic asbClient->closeSender();
+    checkpanic asbClient->closeSender(topicSender);
 
     log:printInfo("Closing Asb receiver connection.");
-    checkpanic asbClient->closeReceiver();
+    checkpanic asbClient->closeReceiver(subscriptionReceiver);
 }    
 ```

--- a/asb-ballerina/samples/abandon_message_from_queue.bal
+++ b/asb-ballerina/samples/abandon_message_from_queue.bal
@@ -19,7 +19,7 @@ import ballerinax/asb;
 
 // Connection Configurations
 configurable string connectionString = ?;
-configurable string queuePath = ?;
+configurable string queueName = ?;
 
 public function main() {
 
@@ -48,22 +48,22 @@ public function main() {
     asb:AsbClient asbClient = new (config);
 
     log:printInfo("Creating Asb sender connection.");
-    checkpanic asbClient->createQueueSender(queuePath);
+    handle queueSender = checkpanic asbClient->createQueueSender(queueName);
 
     log:printInfo("Creating Asb receiver connection.");
-    checkpanic asbClient->createQueueReceiver(queuePath, asb:PEEKLOCK);
+    handle queueReceiver = checkpanic asbClient->createQueueReceiver(queueName, asb:PEEKLOCK);
 
     log:printInfo("Sending via Asb sender connection.");
-    checkpanic asbClient->send(message1);
+    checkpanic asbClient->send(queueSender, message1);
 
     log:printInfo("Receiving from Asb receiver connection.");
-    asb:Message|asb:Error? messageReceived = asbClient->receive(serverWaitTime);
+    asb:Message|asb:Error? messageReceived = asbClient->receive(queueReceiver, serverWaitTime);
 
     if (messageReceived is asb:Message) {
-        checkpanic asbClient->abandon(messageReceived);
-        asb:Message|asb:Error? messageReceivedAgain = asbClient->receive(serverWaitTime);
+        checkpanic asbClient->abandon(queueReceiver, messageReceived);
+        asb:Message|asb:Error? messageReceivedAgain = asbClient->receive(queueReceiver, serverWaitTime);
         if (messageReceivedAgain is asb:Message) {
-            checkpanic asbClient->complete(messageReceivedAgain);
+            checkpanic asbClient->complete(queueReceiver, messageReceivedAgain);
             log:printInfo("Abandon message successful");
         } else {
             log:printError("Abandon message not succesful.");
@@ -75,8 +75,8 @@ public function main() {
     }
 
     log:printInfo("Closing Asb sender connection.");
-    checkpanic asbClient->closeSender();
+    checkpanic asbClient->closeSender(queueSender);
 
     log:printInfo("Closing Asb receiver connection.");
-    checkpanic asbClient->closeReceiver();
+    checkpanic asbClient->closeReceiver(queueReceiver);
 }    

--- a/asb-ballerina/samples/abandon_message_from_subscription.bal
+++ b/asb-ballerina/samples/abandon_message_from_subscription.bal
@@ -19,8 +19,8 @@ import ballerinax/asb;
 
 // Connection Configurations
 configurable string connectionString = ?;
-configurable string topicPath = ?;
-configurable string subscriptionPath1 = ?;
+configurable string topicName = ?;
+configurable string subscriptionName1 = ?;
 
 public function main() {
 
@@ -49,22 +49,23 @@ public function main() {
     asb:AsbClient asbClient = new (config);
 
     log:printInfo("Creating Asb sender connection.");
-    checkpanic asbClient->createTopicSender(topicPath);
+    handle topicSender = checkpanic asbClient->createTopicSender(topicName);
 
     log:printInfo("Creating Asb receiver connection.");
-    checkpanic asbClient->createSubscriptionReceiver(subscriptionPath1, asb:PEEKLOCK);
+    handle subscriptionReceiver = 
+        checkpanic asbClient->createSubscriptionReceiver(topicName, subscriptionName1, asb:PEEKLOCK);
 
     log:printInfo("Sending via Asb sender connection.");
-    checkpanic asbClient->send(message1);
+    checkpanic asbClient->send(topicSender, message1);
 
     log:printInfo("Receiving from Asb receiver connection.");
-    asb:Message|asb:Error? messageReceived = asbClient->receive(serverWaitTime);
+    asb:Message|asb:Error? messageReceived = asbClient->receive(subscriptionReceiver, serverWaitTime);
 
     if (messageReceived is asb:Message) {
-        checkpanic asbClient->abandon(messageReceived);
-        asb:Message|asb:Error? messageReceivedAgain = asbClient->receive(serverWaitTime);
+        checkpanic asbClient->abandon(subscriptionReceiver, messageReceived);
+        asb:Message|asb:Error? messageReceivedAgain = asbClient->receive(subscriptionReceiver, serverWaitTime);
         if (messageReceivedAgain is asb:Message) {
-            checkpanic asbClient->complete(messageReceivedAgain);
+            checkpanic asbClient->complete(subscriptionReceiver, messageReceivedAgain);
             log:printInfo("Abandon message successful");
         } else {
             log:printError("Abandon message not succesful.");
@@ -76,8 +77,8 @@ public function main() {
     }
 
     log:printInfo("Closing Asb sender connection.");
-    checkpanic asbClient->closeSender();
+    checkpanic asbClient->closeSender(topicSender);
 
     log:printInfo("Closing Asb receiver connection.");
-    checkpanic asbClient->closeReceiver();
+    checkpanic asbClient->closeReceiver(subscriptionReceiver);
 }    

--- a/asb-ballerina/samples/async_consumer.bal
+++ b/asb-ballerina/samples/async_consumer.bal
@@ -20,7 +20,7 @@ import ballerinax/asb;
 
 // Connection Configurations
 configurable string connectionString = ?;
-configurable string queuePath = ?;
+configurable string queueName = ?;
 
 public function main() {
 
@@ -48,16 +48,16 @@ public function main() {
     asb:AsbClient asbClient = new (config);
 
     log:printInfo("Creating Asb sender connection.");
-    checkpanic asbClient->createQueueSender(queuePath);
+    handle queueSender = checkpanic asbClient->createQueueSender(queueName);
 
     log:printInfo("Sending via Asb sender connection.");
-    checkpanic asbClient->send(message1);
+    checkpanic asbClient->send(queueSender, message1);
 
     asb:Service asyncTestService =
     @asb:ServiceConfig {
         entityConfig: {
             connectionString: connectionString,
-            entityPath: queuePath
+            entityPath: queueName
         }
     }
     service object {
@@ -80,5 +80,5 @@ public function main() {
     }
 
     log:printInfo("Closing Asb sender connection.");
-    checkpanic asbClient->closeSender();
+    checkpanic asbClient->closeSender(queueSender);
 }    

--- a/asb-ballerina/samples/complete_message_from_subscription.bal
+++ b/asb-ballerina/samples/complete_message_from_subscription.bal
@@ -19,8 +19,8 @@ import ballerinax/asb;
 
 // Connection Configurations
 configurable string connectionString = ?;
-configurable string topicPath = ?;
-configurable string subscriptionPath1 = ?;
+configurable string topicName = ?;
+configurable string subscriptionName1 = ?;
 
 public function main() {
 
@@ -49,19 +49,20 @@ public function main() {
     asb:AsbClient asbClient = new (config);
 
     log:printInfo("Creating Asb sender connection.");
-    checkpanic asbClient->createTopicSender(topicPath);
+    handle topicSender = checkpanic asbClient->createTopicSender(topicName);
 
     log:printInfo("Creating Asb receiver connection.");
-    checkpanic asbClient->createSubscriptionReceiver(subscriptionPath1, asb:PEEKLOCK);
+    handle subscriptionReceiver = 
+        checkpanic asbClient->createSubscriptionReceiver(topicName, subscriptionName1, asb:PEEKLOCK);
 
     log:printInfo("Sending via Asb sender connection.");
-    checkpanic asbClient->send(message1);
+    checkpanic asbClient->send(topicSender, message1);
 
     log:printInfo("Receiving from Asb receiver connection.");
-    asb:Message|asb:Error? messageReceived = asbClient->receive(serverWaitTime);
+    asb:Message|asb:Error? messageReceived = asbClient->receive(subscriptionReceiver, serverWaitTime);
 
     if (messageReceived is asb:Message) {
-        checkpanic asbClient->complete(messageReceived);
+        checkpanic asbClient->complete(subscriptionReceiver, messageReceived);
         log:printInfo("Complete message successful");
     } else if (messageReceived is ()) {
         log:printError("No message in the subscription.");
@@ -70,8 +71,8 @@ public function main() {
     }
 
     log:printInfo("Closing Asb sender connection.");
-    checkpanic asbClient->closeSender();
+    checkpanic asbClient->closeSender(topicSender);
 
     log:printInfo("Closing Asb receiver connection.");
-    checkpanic asbClient->closeReceiver();
+    checkpanic asbClient->closeReceiver(subscriptionReceiver);
 }    

--- a/asb-ballerina/samples/deadletter_from_subscription.bal
+++ b/asb-ballerina/samples/deadletter_from_subscription.bal
@@ -19,8 +19,8 @@ import ballerinax/asb;
 
 // Connection Configurations
 configurable string connectionString = ?;
-configurable string topicPath = ?;
-configurable string subscriptionPath1 = ?;
+configurable string topicName = ?;
+configurable string subscriptionName1 = ?;
 
 public function main() {
 
@@ -49,20 +49,21 @@ public function main() {
     asb:AsbClient asbClient = new (config);
 
     log:printInfo("Creating Asb sender connection.");
-    checkpanic asbClient->createTopicSender(topicPath);
+    handle topicSender = checkpanic asbClient->createTopicSender(topicName);
 
     log:printInfo("Creating Asb receiver connection.");
-    checkpanic asbClient->createSubscriptionReceiver(subscriptionPath1, asb:PEEKLOCK);
+    handle subscriptionReceiver = 
+        checkpanic asbClient->createSubscriptionReceiver(topicName, subscriptionName1, asb:PEEKLOCK);
 
     log:printInfo("Sending via Asb sender connection.");
-    checkpanic asbClient->send(message1);
+    checkpanic asbClient->send(topicSender, message1);
 
     log:printInfo("Receiving from Asb receiver connection.");
-    asb:Message|asb:Error? messageReceived = asbClient->receive(serverWaitTime);
+    asb:Message|asb:Error? messageReceived = asbClient->receive(subscriptionReceiver, serverWaitTime);
 
     if (messageReceived is asb:Message) {
-        checkpanic asbClient->deadLetter(messageReceived);
-        asb:Message|asb:Error? messageReceivedAgain = asbClient->receive(serverWaitTime);
+        checkpanic asbClient->deadLetter(subscriptionReceiver, messageReceived);
+        asb:Message|asb:Error? messageReceivedAgain = asbClient->receive(subscriptionReceiver, serverWaitTime);
         if (messageReceivedAgain is ()) {
             log:printInfo("Deadletter message successful");
         } else {
@@ -75,8 +76,8 @@ public function main() {
     }
 
     log:printInfo("Closing Asb sender connection.");
-    checkpanic asbClient->closeSender();
+    checkpanic asbClient->closeSender(topicSender);
 
     log:printInfo("Closing Asb receiver connection.");
-    checkpanic asbClient->closeReceiver();
+    checkpanic asbClient->closeReceiver(subscriptionReceiver);
 }    

--- a/asb-ballerina/samples/defer_from_queue.bal
+++ b/asb-ballerina/samples/defer_from_queue.bal
@@ -19,7 +19,7 @@ import ballerinax/asb;
 
 // Connection Configurations
 configurable string connectionString = ?;
-configurable string queuePath = ?;
+configurable string queueName = ?;
 
 public function main() {
 
@@ -48,21 +48,22 @@ public function main() {
     asb:AsbClient asbClient = new (config);
 
     log:printInfo("Creating Asb sender connection.");
-    checkpanic asbClient->createQueueSender(queuePath);
+    handle queueSender = checkpanic asbClient->createQueueSender(queueName);
 
     log:printInfo("Creating Asb receiver connection.");
-    checkpanic asbClient->createQueueReceiver(queuePath, asb:PEEKLOCK);
+    handle queueReceiver = checkpanic asbClient->createQueueReceiver(queueName, asb:PEEKLOCK);
 
     log:printInfo("Sending via Asb sender connection.");
-    checkpanic asbClient->send(message1);
+    checkpanic asbClient->send(queueSender, message1);
 
     log:printInfo("Receiving from Asb receiver connection.");
-    asb:Message|asb:Error? messageReceived = asbClient->receive(serverWaitTime);
+    asb:Message|asb:Error? messageReceived = asbClient->receive(queueReceiver, serverWaitTime);
 
     if (messageReceived is asb:Message) {
-        int sequenceNumber = checkpanic asbClient->defer(messageReceived);
+        int sequenceNumber = checkpanic asbClient->defer(queueReceiver, messageReceived);
         log:printInfo("Defer message successful");
-        asb:Message|asb:Error? messageReceivedAgain = checkpanic asbClient->receiveDeferred(sequenceNumber);
+        asb:Message|asb:Error? messageReceivedAgain = 
+            checkpanic asbClient->receiveDeferred(queueReceiver,sequenceNumber);
         if (messageReceivedAgain is asb:Message) {
             log:printInfo("Reading Deferred Message : " + messageReceivedAgain.toString());
         }
@@ -73,8 +74,8 @@ public function main() {
     }
 
     log:printInfo("Closing Asb sender connection.");
-    checkpanic asbClient->closeSender();
+    checkpanic asbClient->closeSender(queueSender);
 
     log:printInfo("Closing Asb receiver connection.");
-    checkpanic asbClient->closeReceiver();
+    checkpanic asbClient->closeReceiver(queueReceiver);
 }    

--- a/asb-ballerina/samples/defer_from_subscription.bal
+++ b/asb-ballerina/samples/defer_from_subscription.bal
@@ -19,8 +19,8 @@ import ballerinax/asb;
 
 // Connection Configurations
 configurable string connectionString = ?;
-configurable string topicPath = ?;
-configurable string subscriptionPath1 = ?;
+configurable string topicName = ?;
+configurable string subscriptionName1 = ?;
 
 public function main() {
 
@@ -49,21 +49,23 @@ public function main() {
     asb:AsbClient asbClient = new (config);
 
     log:printInfo("Creating Asb sender connection.");
-    checkpanic asbClient->createTopicSender(topicPath);
+    handle topicSender = checkpanic asbClient->createTopicSender(topicName);
 
     log:printInfo("Creating Asb receiver connection.");
-    checkpanic asbClient->createSubscriptionReceiver(subscriptionPath1, asb:PEEKLOCK);
+    handle subscriptionReceiver = 
+        checkpanic asbClient->createSubscriptionReceiver(topicName, subscriptionName1, asb:PEEKLOCK);
 
     log:printInfo("Sending via Asb sender connection.");
-    checkpanic asbClient->send(message1);
+    checkpanic asbClient->send(topicSender, message1);
 
     log:printInfo("Receiving from Asb receiver connection.");
-    asb:Message|asb:Error? messageReceived = asbClient->receive(serverWaitTime);
+    asb:Message|asb:Error? messageReceived = asbClient->receive(subscriptionReceiver, serverWaitTime);
 
     if (messageReceived is asb:Message) {
-        int sequenceNumber = checkpanic asbClient->defer(messageReceived);
+        int sequenceNumber = checkpanic asbClient->defer(subscriptionReceiver, messageReceived);
         log:printInfo("Defer message successful");
-        asb:Message|asb:Error? messageReceivedAgain = checkpanic asbClient->receiveDeferred(sequenceNumber);
+        asb:Message|asb:Error? messageReceivedAgain = 
+            checkpanic asbClient->receiveDeferred(subscriptionReceiver, sequenceNumber);
         if (messageReceivedAgain is asb:Message) {
             log:printInfo("Reading Deferred Message : " + messageReceivedAgain.toString());
         }
@@ -74,8 +76,8 @@ public function main() {
     }
 
     log:printInfo("Closing Asb sender connection.");
-    checkpanic asbClient->closeSender();
+    checkpanic asbClient->closeSender(topicSender);
 
     log:printInfo("Closing Asb receiver connection.");
-    checkpanic asbClient->closeReceiver();
+    checkpanic asbClient->closeReceiver(subscriptionReceiver);
 }    

--- a/asb-ballerina/samples/renew_lock_on_message_from_queue.bal
+++ b/asb-ballerina/samples/renew_lock_on_message_from_queue.bal
@@ -19,7 +19,7 @@ import ballerinax/asb;
 
 // Connection Configurations
 configurable string connectionString = ?;
-configurable string queuePath = ?;
+configurable string queueName = ?;
 
 public function main() {
 
@@ -48,25 +48,20 @@ public function main() {
     asb:AsbClient asbClient = new (config);
 
     log:printInfo("Creating Asb sender connection.");
-    checkpanic asbClient->createQueueSender(queuePath);
+    handle queueSender = checkpanic asbClient->createQueueSender(queueName);
 
     log:printInfo("Creating Asb receiver connection.");
-    checkpanic asbClient->createQueueReceiver(queuePath, asb:PEEKLOCK);
+    handle queueReceiver = checkpanic asbClient->createQueueReceiver(queueName, asb:PEEKLOCK);
 
     log:printInfo("Sending via Asb sender connection.");
-    checkpanic asbClient->send(message1);
+    checkpanic asbClient->send(queueSender, message1);
 
     log:printInfo("Receiving from Asb receiver connection.");
-    asb:Message|asb:Error? messageReceived = asbClient->receive(serverWaitTime);
+    asb:Message|asb:Error? messageReceived = asbClient->receive(queueReceiver, serverWaitTime);
 
     if (messageReceived is asb:Message) {
-        checkpanic asbClient->renewLock(messageReceived);
-        asb:Message|asb:Error? messageReceivedAgain = asbClient->receive(serverWaitTime);
-        if (messageReceivedAgain is ()) {
-            log:printInfo("Renew lock message successful");
-        } else {
-            log:printError("Renew lock on message not succesful.");
-        }
+        checkpanic asbClient->renewLock(queueReceiver, messageReceived);
+        log:printInfo("Renew lock message successful");
     } else if (messageReceived is ()) {
         log:printError("No message in the queue.");
     } else {
@@ -74,8 +69,8 @@ public function main() {
     }
 
     log:printInfo("Closing Asb sender connection.");
-    checkpanic asbClient->closeSender();
+    checkpanic asbClient->closeSender(queueSender);
 
     log:printInfo("Closing Asb receiver connection.");
-    checkpanic asbClient->closeReceiver();
+    checkpanic asbClient->closeReceiver(queueReceiver);
 }    

--- a/asb-ballerina/samples/renew_lock_on_message_from_subscription.bal
+++ b/asb-ballerina/samples/renew_lock_on_message_from_subscription.bal
@@ -19,8 +19,8 @@ import ballerinax/asb;
 
 // Connection Configurations
 configurable string connectionString = ?;
-configurable string topicPath = ?;
-configurable string subscriptionPath1 = ?;
+configurable string topicName = ?;
+configurable string subscriptionName1 = ?;
 
 public function main() {
 
@@ -49,25 +49,22 @@ public function main() {
     asb:AsbClient asbClient = new (config);
 
     log:printInfo("Creating Asb sender connection.");
-    checkpanic asbClient->createTopicSender(topicPath);
+    handle topicSender = checkpanic asbClient->createTopicSender(topicName);
 
     log:printInfo("Creating Asb receiver connection.");
-    checkpanic asbClient->createSubscriptionReceiver(subscriptionPath1, asb:PEEKLOCK);
+    handle subscriptionReceiver = 
+        checkpanic asbClient->createSubscriptionReceiver(topicName, subscriptionName1, asb:PEEKLOCK);
     
     log:printInfo("Sending via Asb sender connection.");
-    checkpanic asbClient->send(message1);
+    checkpanic asbClient->send(topicSender, message1);
 
     log:printInfo("Receiving from Asb receiver connection.");
-    asb:Message|asb:Error? messageReceived = asbClient->receive(serverWaitTime);
+    asb:Message|asb:Error? messageReceived = asbClient->receive(subscriptionReceiver, serverWaitTime);
 
     if (messageReceived is asb:Message) {
-        checkpanic asbClient->renewLock(messageReceived);
-        asb:Message|asb:Error? messageReceivedAgain = asbClient->receive(serverWaitTime);
-        if (messageReceivedAgain is ()) {
-            log:printInfo("Renew lock message successful");
-        } else {
-            log:printError("Renew lock on message not succesful.");
-        }
+        checkpanic asbClient->renewLock(subscriptionReceiver, messageReceived);
+        asb:Message|asb:Error? messageReceivedAgain = asbClient->receive(subscriptionReceiver, serverWaitTime);
+        log:printInfo("Renew lock message successful");
     } else if (messageReceived is ()) {
         log:printError("No message in the queue.");
     } else {
@@ -75,8 +72,8 @@ public function main() {
     }
 
     log:printInfo("Closing Asb sender connection.");
-    checkpanic asbClient->closeSender();
+    checkpanic asbClient->closeSender(topicSender);
 
     log:printInfo("Closing Asb receiver connection.");
-    checkpanic asbClient->closeReceiver();
+    checkpanic asbClient->closeReceiver(subscriptionReceiver);
 }    

--- a/asb-ballerina/samples/send_and_receive_batch_from_queue.bal
+++ b/asb-ballerina/samples/send_and_receive_batch_from_queue.bal
@@ -19,7 +19,7 @@ import ballerinax/asb;
 
 // Connection Configurations
 configurable string connectionString = ?;
-configurable string queuePath = ?;
+configurable string queueName = ?;
 
 public function main() {
 
@@ -59,16 +59,17 @@ public function main() {
     asb:AsbClient asbClient = new (config);
 
     log:printInfo("Creating Asb sender connection.");
-    checkpanic asbClient->createQueueSender(queuePath);
+    handle queueSender = checkpanic asbClient->createQueueSender(queueName);
 
     log:printInfo("Creating Asb receiver connection.");
-    checkpanic asbClient->createQueueReceiver(queuePath, asb:RECEIVEANDDELETE);
+    handle queueReceiver = checkpanic asbClient->createQueueReceiver(queueName, asb:RECEIVEANDDELETE);
 
     log:printInfo("Sending via Asb sender connection.");
-    checkpanic asbClient->sendBatch(messages);
+    checkpanic asbClient->sendBatch(queueSender, messages);
 
     log:printInfo("Receiving from Asb receiver connection.");
-    asb:MessageBatch|asb:Error? messageReceived = asbClient->receiveBatch(maxMessageCount, serverWaitTime);
+    asb:MessageBatch|asb:Error? messageReceived = 
+        asbClient->receiveBatch(queueReceiver, maxMessageCount, serverWaitTime);
 
     if (messageReceived is asb:MessageBatch) {
         foreach asb:Message message in messageReceived.messages {
@@ -83,8 +84,8 @@ public function main() {
     }
 
     log:printInfo("Closing Asb sender connection.");
-    checkpanic asbClient->closeSender();
+    checkpanic asbClient->closeSender(queueSender);
 
     log:printInfo("Closing Asb receiver connection.");
-    checkpanic asbClient->closeReceiver();
+    checkpanic asbClient->closeReceiver(queueReceiver);
 }    

--- a/asb-ballerina/samples/send_and_receive_message_from_queue.bal
+++ b/asb-ballerina/samples/send_and_receive_message_from_queue.bal
@@ -19,7 +19,7 @@ import ballerinax/asb;
 
 // Connection Configurations
 configurable string connectionString = ?;
-configurable string queuePath = ?;
+configurable string queueName = ?;
 
 public function main() {
 
@@ -48,16 +48,16 @@ public function main() {
     asb:AsbClient asbClient = new (config);
 
     log:printInfo("Creating Asb sender connection.");
-    checkpanic asbClient->createQueueSender(queuePath);
+    handle queueSender = checkpanic asbClient->createQueueSender(queueName);
 
     log:printInfo("Creating Asb receiver connection.");
-    checkpanic asbClient->createQueueReceiver(queuePath, asb:RECEIVEANDDELETE);
+    handle queueReceiver = checkpanic asbClient->createQueueReceiver(queueName, asb:RECEIVEANDDELETE);
 
     log:printInfo("Sending via Asb sender connection.");
-    checkpanic asbClient->send(message1);
+    checkpanic asbClient->send(queueSender, message1);
 
     log:printInfo("Receiving from Asb receiver connection.");
-    asb:Message|asb:Error? messageReceived = asbClient->receive(serverWaitTime);
+    asb:Message|asb:Error? messageReceived = asbClient->receive(queueReceiver, serverWaitTime);
 
     if (messageReceived is asb:Message) {
         log:printInfo("Reading Received Message : " + messageReceived.toString());
@@ -68,8 +68,8 @@ public function main() {
     }
 
     log:printInfo("Closing Asb sender connection.");
-    checkpanic asbClient->closeSender();
+    checkpanic asbClient->closeSender(queueSender);
 
     log:printInfo("Closing Asb receiver connection.");
-    checkpanic asbClient->closeReceiver();
+    checkpanic asbClient->closeReceiver(queueReceiver);
 }    

--- a/asb-ballerina/samples/send_to_topic_and_receive_from_subscription.bal
+++ b/asb-ballerina/samples/send_to_topic_and_receive_from_subscription.bal
@@ -19,8 +19,8 @@ import ballerinax/asb;
 
 // Connection Configurations
 configurable string connectionString = ?;
-configurable string topicPath = ?;
-configurable string subscriptionPath1 = ?;
+configurable string topicName = ?;
+configurable string subscriptionName1 = ?;
 
 public function main() {
 
@@ -49,16 +49,17 @@ public function main() {
     asb:AsbClient asbClient = new (config);
 
     log:printInfo("Creating Asb sender connection.");
-    checkpanic asbClient->createTopicSender(topicPath);
+    handle topicSender = checkpanic asbClient->createTopicSender(topicName);
 
     log:printInfo("Creating Asb receiver connection.");
-    checkpanic asbClient->createSubscriptionReceiver(subscriptionPath1, asb:RECEIVEANDDELETE);
+    handle subscriptionReceiver = 
+        checkpanic asbClient->createSubscriptionReceiver(topicName, subscriptionName1, asb:RECEIVEANDDELETE);
 
     log:printInfo("Sending via Asb sender connection.");
-    checkpanic asbClient->send(message1);
+    checkpanic asbClient->send(topicSender, message1);
 
     log:printInfo("Receiving from Asb receiver connection.");
-    asb:Message|asb:Error? messageReceived = asbClient->receive(serverWaitTime);
+    asb:Message|asb:Error? messageReceived = asbClient->receive(subscriptionReceiver, serverWaitTime);
 
     if (messageReceived is asb:Message) {
         log:printInfo("Reading Received Message : " + messageReceived.toString());
@@ -69,8 +70,8 @@ public function main() {
     }
 
     log:printInfo("Closing Asb sender connection.");
-    checkpanic asbClient->closeSender();
+    checkpanic asbClient->closeSender(topicSender);
 
     log:printInfo("Closing Asb receiver connection.");
-    checkpanic asbClient->closeReceiver();
+    checkpanic asbClient->closeReceiver(subscriptionReceiver);
 }    

--- a/asb-ballerina/tests/asb_test.bal
+++ b/asb-ballerina/tests/asb_test.bal
@@ -70,16 +70,16 @@ function testSendAndReceiveMessageFromQueueOperation() {
     AsbClient asbClient = new (config);
 
     log:printInfo("Creating Asb sender connection.");
-    checkpanic asbClient->createQueueSender(queueName);
+    handle queueSender = checkpanic asbClient->createQueueSender(queueName);
 
     log:printInfo("Creating Asb receiver connection.");
-    checkpanic asbClient->createQueueReceiver(queueName, RECEIVEANDDELETE);
+    handle queueReceiver = checkpanic asbClient->createQueueReceiver(queueName, RECEIVEANDDELETE);
 
     log:printInfo("Sending via Asb sender connection.");
-    checkpanic asbClient->send(message1);
+    checkpanic asbClient->send(queueSender, message1);
 
     log:printInfo("Receiving from Asb receiver connection.");
-    Message|Error? messageReceived = asbClient->receive(serverWaitTime);
+    Message|Error? messageReceived = asbClient->receive(queueReceiver, serverWaitTime);
 
     if (messageReceived is Message) {
         log:printInfo(messageReceived.toString());
@@ -91,10 +91,10 @@ function testSendAndReceiveMessageFromQueueOperation() {
     }
 
     log:printInfo("Closing Asb sender connection.");
-    checkpanic asbClient->closeSender();
+    checkpanic asbClient->closeSender(queueSender);
 
     log:printInfo("Closing Asb receiver connection.");
-    checkpanic asbClient->closeReceiver();
+    checkpanic asbClient->closeReceiver(queueReceiver);
 }
 
 @test:Config { 
@@ -107,16 +107,16 @@ function testSendAndReceiveBatchFromQueueOperation() {
     AsbClient asbClient = new (config);
 
     log:printInfo("Creating Asb sender connection.");
-    checkpanic asbClient->createQueueSender(queueName);
+    handle queueSender = checkpanic asbClient->createQueueSender(queueName);
 
     log:printInfo("Creating Asb receiver connection.");
-    checkpanic asbClient->createQueueReceiver(queueName, RECEIVEANDDELETE);
+    handle queueReceiver = checkpanic asbClient->createQueueReceiver(queueName, RECEIVEANDDELETE);
 
     log:printInfo("Sending via Asb sender connection.");
-    checkpanic asbClient->sendBatch(messages);
+    checkpanic asbClient->sendBatch(queueSender, messages);
 
     log:printInfo("Receiving from Asb receiver connection.");
-    MessageBatch|Error? messageReceived = asbClient->receiveBatch(maxMessageCount);
+    MessageBatch|Error? messageReceived = asbClient->receiveBatch(queueReceiver, maxMessageCount);
 
     if (messageReceived is MessageBatch) {
         log:printInfo(messageReceived.toString());
@@ -132,10 +132,10 @@ function testSendAndReceiveBatchFromQueueOperation() {
     }
 
     log:printInfo("Closing Asb sender connection.");
-    checkpanic asbClient->closeSender();
+    checkpanic asbClient->closeSender(queueSender);
 
     log:printInfo("Closing Asb receiver connection.");
-    checkpanic asbClient->closeReceiver();
+    checkpanic asbClient->closeReceiver(queueReceiver);
 }
 
 @test:Config { 
@@ -148,19 +148,19 @@ function testCompleteMessageFromQueueOperation() {
     AsbClient asbClient = new (config);
 
     log:printInfo("Creating Asb sender connection.");
-    checkpanic asbClient->createQueueSender(queueName);
+    handle queueSender = checkpanic asbClient->createQueueSender(queueName);
 
     log:printInfo("Creating Asb receiver connection.");
-    checkpanic asbClient->createQueueReceiver(queueName, PEEKLOCK);
+    handle queueReceiver = checkpanic asbClient->createQueueReceiver(queueName, PEEKLOCK);
 
     log:printInfo("Sending via Asb sender connection.");
-    checkpanic asbClient->send(message1);
+    checkpanic asbClient->send(queueSender, message1);
 
     log:printInfo("Receiving from Asb receiver connection.");
-    Message|Error? messageReceived = asbClient->receive(serverWaitTime);
+    Message|Error? messageReceived = asbClient->receive(queueReceiver, serverWaitTime);
 
     if (messageReceived is Message) {
-        var result = checkpanic asbClient->complete(messageReceived);
+        var result = checkpanic asbClient->complete(queueReceiver, messageReceived);
         test:assertEquals(result, (), msg = "Complete message not succesful.");
     } else if (messageReceived is ()) {
         test:assertFail("No message in the queue.");
@@ -169,10 +169,10 @@ function testCompleteMessageFromQueueOperation() {
     }
 
     log:printInfo("Closing Asb sender connection.");
-    checkpanic asbClient->closeSender();
+    checkpanic asbClient->closeSender(queueSender);
 
     log:printInfo("Closing Asb receiver connection.");
-    checkpanic asbClient->closeReceiver();
+    checkpanic asbClient->closeReceiver(queueReceiver);
 }
 
 @test:Config { 
@@ -185,25 +185,25 @@ function testAbandonMessageFromQueueOperation() {
     AsbClient asbClient = new (config);
 
     log:printInfo("Creating Asb sender connection.");
-    checkpanic asbClient->createQueueSender(queueName);
+    handle queueSender = checkpanic asbClient->createQueueSender(queueName);
 
     log:printInfo("Creating Asb receiver connection.");
-    checkpanic asbClient->createQueueReceiver(queueName, PEEKLOCK);
+    handle queueReceiver = checkpanic asbClient->createQueueReceiver(queueName, PEEKLOCK);
 
     log:printInfo("Sending via Asb sender connection.");
-    checkpanic asbClient->send(message1);
+    checkpanic asbClient->send(queueSender, message1);
 
     log:printInfo("Receiving from Asb receiver connection.");
-    Message|Error? messageReceived = asbClient->receive(serverWaitTime);
+    Message|Error? messageReceived = asbClient->receive(queueReceiver, serverWaitTime);
 
     if (messageReceived is Message) {
-        var result = checkpanic asbClient->abandon(messageReceived);
+        var result = checkpanic asbClient->abandon(queueReceiver, messageReceived);
         test:assertEquals(result, (), msg = "Abandon message not succesful.");
-        Message|Error? messageReceivedAgain = asbClient->receive(serverWaitTime);
+        Message|Error? messageReceivedAgain = asbClient->receive(queueReceiver, serverWaitTime);
         if (messageReceivedAgain is Message) {
             test:assertEquals(messageReceivedAgain?.messageId, messageReceived?.messageId, 
                 msg = "Abandon message not succesful.");
-            checkpanic asbClient->complete(messageReceivedAgain);
+            checkpanic asbClient->complete(queueReceiver, messageReceivedAgain);
         } else {
             test:assertFail("Abandon message not succesful.");
         }
@@ -214,10 +214,10 @@ function testAbandonMessageFromQueueOperation() {
     }
 
     log:printInfo("Closing Asb sender connection.");
-    checkpanic asbClient->closeSender();
+    checkpanic asbClient->closeSender(queueSender);
 
     log:printInfo("Closing Asb receiver connection.");
-    checkpanic asbClient->closeReceiver();
+    checkpanic asbClient->closeReceiver(queueReceiver);
 }
 
 @test:Config { 
@@ -230,19 +230,19 @@ function testDeadletterMessageFromQueueOperation() {
     AsbClient asbClient = new (config);
 
     log:printInfo("Creating Asb sender connection.");
-    checkpanic asbClient->createQueueSender(queueName);
+    handle queueSender = checkpanic asbClient->createQueueSender(queueName);
 
     log:printInfo("Creating Asb receiver connection.");
-    checkpanic asbClient->createQueueReceiver(queueName, PEEKLOCK);
+    handle queueReceiver = checkpanic asbClient->createQueueReceiver(queueName, PEEKLOCK);
 
     log:printInfo("Sending via Asb sender connection.");
-    checkpanic asbClient->send(message1);
+    checkpanic asbClient->send(queueSender, message1);
 
     log:printInfo("Receiving from Asb receiver connection.");
-    Message|Error? messageReceived = asbClient->receive(serverWaitTime);
+    Message|Error? messageReceived = asbClient->receive(queueReceiver, serverWaitTime);
 
     if (messageReceived is Message) {
-        var result = checkpanic asbClient->deadLetter(messageReceived);
+        var result = checkpanic asbClient->deadLetter(queueReceiver, messageReceived);
         test:assertEquals(result, (), msg = "Deadletter message not succesful.");
     } else if (messageReceived is ()) {
         test:assertFail("No message in the queue.");
@@ -251,10 +251,10 @@ function testDeadletterMessageFromQueueOperation() {
     }
 
     log:printInfo("Closing Asb sender connection.");
-    checkpanic asbClient->closeSender();
+    checkpanic asbClient->closeSender(queueSender);
 
     log:printInfo("Closing Asb receiver connection.");
-    checkpanic asbClient->closeReceiver();
+    checkpanic asbClient->closeReceiver(queueReceiver);
 }
 
 @test:Config { 
@@ -267,25 +267,25 @@ function testDeferMessageFromQueueOperation() {
     AsbClient asbClient = new (config);
 
     log:printInfo("Creating Asb sender connection.");
-    checkpanic asbClient->createQueueSender(queueName);
+    handle queueSender = checkpanic asbClient->createQueueSender(queueName);
 
     log:printInfo("Creating Asb receiver connection.");
-    checkpanic asbClient->createQueueReceiver(queueName, PEEKLOCK);
+    handle queueReceiver = checkpanic asbClient->createQueueReceiver(queueName, PEEKLOCK);
 
     log:printInfo("Sending via Asb sender connection.");
-    checkpanic asbClient->send(message1);
+    checkpanic asbClient->send(queueSender, message1);
 
     log:printInfo("Receiving from Asb receiver connection.");
-    Message|Error? messageReceived = asbClient->receive(serverWaitTime);
+    Message|Error? messageReceived = asbClient->receive(queueReceiver, serverWaitTime);
 
     if (messageReceived is Message) {
-        int result = checkpanic asbClient->defer(messageReceived);
+        int result = checkpanic asbClient->defer(queueReceiver, messageReceived);
         test:assertNotEquals(result, 0, msg = "Defer message not succesful.");
-        Message|Error? messageReceivedAgain = checkpanic asbClient->receiveDeferred(result);
+        Message|Error? messageReceivedAgain = checkpanic asbClient->receiveDeferred(queueReceiver, result);
         if (messageReceivedAgain is Message) {
             test:assertEquals(messageReceivedAgain?.messageId, messageReceived?.messageId, 
                 msg = "Receiving deferred message not succesful.");
-            checkpanic asbClient->complete(messageReceivedAgain);
+            checkpanic asbClient->complete(queueReceiver, messageReceivedAgain);
         }
     } else if (messageReceived is ()) {
         test:assertFail("No message in the queue.");
@@ -294,10 +294,10 @@ function testDeferMessageFromQueueOperation() {
     }
 
     log:printInfo("Closing Asb sender connection.");
-    checkpanic asbClient->closeSender();
+    checkpanic asbClient->closeSender(queueSender);
 
     log:printInfo("Closing Asb receiver connection.");
-    checkpanic asbClient->closeReceiver();
+    checkpanic asbClient->closeReceiver(queueReceiver);
 }
 
 @test:Config { 
@@ -310,16 +310,17 @@ function testSendAndReceiveMessageFromSubscriptionOperation() {
     AsbClient asbClient = new (config);
 
     log:printInfo("Creating Asb sender connection.");
-    checkpanic asbClient->createTopicSender(topicName);
+    handle topicSender = checkpanic asbClient->createTopicSender(topicName);
 
     log:printInfo("Creating Asb receiver connection.");
-    checkpanic asbClient->createSubscriptionReceiver(topicName, subscriptionName1, RECEIVEANDDELETE);
+    handle subscriptionReceiver = 
+        checkpanic asbClient->createSubscriptionReceiver(topicName, subscriptionName1, RECEIVEANDDELETE);
 
     log:printInfo("Sending via Asb sender connection.");
-    checkpanic asbClient->send(message1);
+    checkpanic asbClient->send(topicSender, message1);
 
     log:printInfo("Receiving from Asb receiver connection.");
-    Message|Error? messageReceived = asbClient->receive(serverWaitTime);
+    Message|Error? messageReceived = asbClient->receive(subscriptionReceiver, serverWaitTime);
 
     if (messageReceived is Message) {
         test:assertEquals(messageReceived.body, stringContent, msg = "Sent & recieved message not equal.");
@@ -330,10 +331,10 @@ function testSendAndReceiveMessageFromSubscriptionOperation() {
     }
 
     log:printInfo("Closing Asb sender connection.");
-    checkpanic asbClient->closeSender();
+    checkpanic asbClient->closeSender(topicSender);
 
     log:printInfo("Closing Asb receiver connection.");
-    checkpanic asbClient->closeReceiver();
+    checkpanic asbClient->closeReceiver(subscriptionReceiver);
 }
 
 @test:Config { 
@@ -346,16 +347,18 @@ function testSendAndReceiveBatchFromSubscriptionOperation() {
     AsbClient asbClient = new (config);
 
     log:printInfo("Creating Asb sender connection.");
-    checkpanic asbClient->createTopicSender(topicName);
+    handle topicSender = checkpanic asbClient->createTopicSender(topicName);
 
     log:printInfo("Creating Asb receiver connection.");
-    checkpanic asbClient->createSubscriptionReceiver(topicName, subscriptionName1, RECEIVEANDDELETE);
+    handle subscriptionReceiver = 
+        checkpanic asbClient->createSubscriptionReceiver(topicName, subscriptionName1, RECEIVEANDDELETE);
 
     log:printInfo("Sending via Asb sender connection.");
-    checkpanic asbClient->sendBatch(messages);
+    checkpanic asbClient->sendBatch(topicSender, messages);
 
     log:printInfo("Receiving from Asb receiver connection.");
-    MessageBatch|Error? messageReceived = asbClient->receiveBatch(maxMessageCount, serverWaitTime);
+    MessageBatch|Error? messageReceived = 
+        asbClient->receiveBatch(subscriptionReceiver, maxMessageCount, serverWaitTime);
 
     if (messageReceived is MessageBatch) {
         foreach Message message in messageReceived.messages {
@@ -370,10 +373,10 @@ function testSendAndReceiveBatchFromSubscriptionOperation() {
     }
 
     log:printInfo("Closing Asb sender connection.");
-    checkpanic asbClient->closeSender();
+    checkpanic asbClient->closeSender(topicSender);
 
     log:printInfo("Closing Asb receiver connection.");
-    checkpanic asbClient->closeReceiver();
+    checkpanic asbClient->closeReceiver(subscriptionReceiver);
 }
 
 @test:Config { 
@@ -386,19 +389,20 @@ function testCompleteMessageFromSubscriptionOperation() {
     AsbClient asbClient = new (config);
 
     log:printInfo("Creating Asb sender connection.");
-    checkpanic asbClient->createTopicSender(topicName);
+    handle topicSender = checkpanic asbClient->createTopicSender(topicName);
 
     log:printInfo("Creating Asb receiver connection.");
-    checkpanic asbClient->createSubscriptionReceiver(topicName, subscriptionName1, PEEKLOCK);
+    handle subscriptionReceiver = 
+        checkpanic asbClient->createSubscriptionReceiver(topicName, subscriptionName1, PEEKLOCK);
 
     log:printInfo("Sending via Asb sender connection.");
-    checkpanic asbClient->send(message1);
+    checkpanic asbClient->send(topicSender, message1);
 
     log:printInfo("Receiving from Asb receiver connection.");
-    Message|Error? messageReceived = asbClient->receive(serverWaitTime);
+    Message|Error? messageReceived = asbClient->receive(subscriptionReceiver, serverWaitTime);
 
     if (messageReceived is Message) {
-        var result = checkpanic asbClient->complete(messageReceived);
+        var result = checkpanic asbClient->complete(subscriptionReceiver, messageReceived);
         test:assertEquals(result, (), msg = "Complete message not succesful.");
     } else if (messageReceived is ()) {
         test:assertFail("No message in the subscription.");
@@ -407,10 +411,10 @@ function testCompleteMessageFromSubscriptionOperation() {
     }
 
     log:printInfo("Closing Asb sender connection.");
-    checkpanic asbClient->closeSender();
+    checkpanic asbClient->closeSender(topicSender);
 
     log:printInfo("Closing Asb receiver connection.");
-    checkpanic asbClient->closeReceiver();
+    checkpanic asbClient->closeReceiver(subscriptionReceiver);
 }
 
 @test:Config { 
@@ -423,23 +427,24 @@ function testAbandonMessageFromSubscriptionOperation() {
     AsbClient asbClient = new (config);
 
     log:printInfo("Creating Asb sender connection.");
-    checkpanic asbClient->createTopicSender(topicName);
+    handle topicSender = checkpanic asbClient->createTopicSender(topicName);
 
     log:printInfo("Creating Asb receiver connection.");
-    checkpanic asbClient->createSubscriptionReceiver(topicName, subscriptionName1, PEEKLOCK);
+    handle subscriptionReceiver = 
+        checkpanic asbClient->createSubscriptionReceiver(topicName, subscriptionName1, PEEKLOCK);
 
     log:printInfo("Sending via Asb sender connection.");
-    checkpanic asbClient->send(message1);
+    checkpanic asbClient->send(topicSender, message1);
 
     log:printInfo("Receiving from Asb receiver connection.");
-    Message|Error? messageReceived = asbClient->receive(serverWaitTime);
+    Message|Error? messageReceived = asbClient->receive(subscriptionReceiver, serverWaitTime);
 
     if (messageReceived is Message) {
-        var result = checkpanic asbClient->abandon(messageReceived);
+        var result = checkpanic asbClient->abandon(subscriptionReceiver, messageReceived);
         test:assertEquals(result, (), msg = "Abandon message not succesful.");
-        Message|Error? messageReceivedAgain = asbClient->receive(serverWaitTime);
+        Message|Error? messageReceivedAgain = asbClient->receive(subscriptionReceiver, serverWaitTime);
         if (messageReceivedAgain is Message) {
-            checkpanic asbClient->complete(messageReceivedAgain);
+            checkpanic asbClient->complete(subscriptionReceiver, messageReceivedAgain);
         } else {
             test:assertFail("Abandon message not succesful.");
         }
@@ -450,10 +455,10 @@ function testAbandonMessageFromSubscriptionOperation() {
     }
 
     log:printInfo("Closing Asb sender connection.");
-    checkpanic asbClient->closeSender();
+    checkpanic asbClient->closeSender(topicSender);
 
     log:printInfo("Closing Asb receiver connection.");
-    checkpanic asbClient->closeReceiver();
+    checkpanic asbClient->closeReceiver(subscriptionReceiver);
 }
 
 @test:Config { 
@@ -466,19 +471,20 @@ function testDeadletterMessageFromSubscriptionOperation() {
     AsbClient asbClient = new (config);
 
     log:printInfo("Creating Asb sender connection.");
-    checkpanic asbClient->createTopicSender(topicName);
+    handle topicSender = checkpanic asbClient->createTopicSender(topicName);
 
     log:printInfo("Creating Asb receiver connection.");
-    checkpanic asbClient->createSubscriptionReceiver(topicName, subscriptionName1, PEEKLOCK);
+    handle subscriptionReceiver = 
+        checkpanic asbClient->createSubscriptionReceiver(topicName, subscriptionName1, PEEKLOCK);
 
     log:printInfo("Sending via Asb sender connection.");
-    checkpanic asbClient->send(message1);
+    checkpanic asbClient->send(topicSender, message1);
 
     log:printInfo("Receiving from Asb receiver connection.");
-    Message|Error? messageReceived = asbClient->receive(serverWaitTime);
+    Message|Error? messageReceived = asbClient->receive(subscriptionReceiver, serverWaitTime);
 
     if (messageReceived is Message) {
-        var result = checkpanic asbClient->deadLetter(messageReceived);
+        var result = checkpanic asbClient->deadLetter(subscriptionReceiver, messageReceived);
         test:assertEquals(result, (), msg = "Deadletter message not succesful.");
     } else if (messageReceived is ()) {
         test:assertFail("No message in the subscription.");
@@ -487,10 +493,10 @@ function testDeadletterMessageFromSubscriptionOperation() {
     }
 
     log:printInfo("Closing Asb sender connection.");
-    checkpanic asbClient->closeSender();
+    checkpanic asbClient->closeSender(topicSender);
 
     log:printInfo("Closing Asb receiver connection.");
-    checkpanic asbClient->closeReceiver();
+    checkpanic asbClient->closeReceiver(subscriptionReceiver);
 }
 
 @test:Config { 
@@ -503,25 +509,26 @@ function testDeferMessageFromSubscriptionOperation() {
     AsbClient asbClient = new (config);
 
     log:printInfo("Creating Asb sender connection.");
-    checkpanic asbClient->createTopicSender(topicName);
+    handle topicSender = checkpanic asbClient->createTopicSender(topicName);
 
     log:printInfo("Creating Asb receiver connection.");
-    checkpanic asbClient->createSubscriptionReceiver(topicName, subscriptionName1, PEEKLOCK);
+    handle subscriptionReceiver = 
+        checkpanic asbClient->createSubscriptionReceiver(topicName, subscriptionName1, PEEKLOCK);
 
     log:printInfo("Sending via Asb sender connection.");
-    checkpanic asbClient->send(message1);
+    checkpanic asbClient->send(topicSender, message1);
 
     log:printInfo("Receiving from Asb receiver connection.");
-    Message|Error? messageReceived = asbClient->receive(serverWaitTime);
+    Message|Error? messageReceived = asbClient->receive(subscriptionReceiver, serverWaitTime);
 
     if (messageReceived is Message) {
-        int result = checkpanic asbClient->defer(messageReceived);
+        int result = checkpanic asbClient->defer(subscriptionReceiver, messageReceived);
         test:assertNotEquals(result, 0, msg = "Defer message not succesful.");
-        Message|Error? messageReceivedAgain = checkpanic asbClient->receiveDeferred(result);
+        Message|Error? messageReceivedAgain = checkpanic asbClient->receiveDeferred(subscriptionReceiver, result);
         if (messageReceivedAgain is Message) {
             test:assertEquals(messageReceivedAgain?.messageId, messageReceived?.messageId, 
                 msg = "Receiving deferred message not succesful.");
-            checkpanic asbClient->complete(messageReceivedAgain);
+            checkpanic asbClient->complete(subscriptionReceiver, messageReceivedAgain);
         }
     } else if (messageReceived is ()) {
         test:assertFail("No message in the queue.");
@@ -530,8 +537,8 @@ function testDeferMessageFromSubscriptionOperation() {
     }
 
     log:printInfo("Closing Asb sender connection.");
-    checkpanic asbClient->closeSender();
+    checkpanic asbClient->closeSender(topicSender);
 
     log:printInfo("Closing Asb receiver connection.");
-    checkpanic asbClient->closeReceiver();
+    checkpanic asbClient->closeReceiver(subscriptionReceiver);
 }

--- a/asb-ballerina/tests/asb_test.bal
+++ b/asb-ballerina/tests/asb_test.bal
@@ -20,11 +20,11 @@ import ballerina/test;
 
 // Connection Configurations
 configurable string connectionString = os:getEnv("CONNECTION_STRING");
-configurable string queuePath = os:getEnv("QUEUE_PATH");
-configurable string topicPath = os:getEnv("TOPIC_PATH");
-configurable string subscriptionPath1 = os:getEnv("SUBSCRIPTION_PATH1");
-configurable string subscriptionPath2 = os:getEnv("SUBSCRIPTION_PATH2");
-configurable string subscriptionPath3 = os:getEnv("SUBSCRIPTION_PATH3");
+configurable string queueName = os:getEnv("QUEUE_NAME");
+configurable string topicName = os:getEnv("TOPIC_NAME");
+configurable string subscriptionName1 = os:getEnv("SUBSCRIPTION_NAME1");
+configurable string subscriptionName2 = os:getEnv("SUBSCRIPTION_NAME2");
+configurable string subscriptionName3 = os:getEnv("SUBSCRIPTION_NAME3");
 
 // Input values
 string stringContent = "This is My Message Body"; 
@@ -70,10 +70,10 @@ function testSendAndReceiveMessageFromQueueOperation() {
     AsbClient asbClient = new (config);
 
     log:printInfo("Creating Asb sender connection.");
-    checkpanic asbClient->createQueueSender(queuePath);
+    checkpanic asbClient->createQueueSender(queueName);
 
     log:printInfo("Creating Asb receiver connection.");
-    checkpanic asbClient->createQueueReceiver(queuePath, RECEIVEANDDELETE);
+    checkpanic asbClient->createQueueReceiver(queueName, RECEIVEANDDELETE);
 
     log:printInfo("Sending via Asb sender connection.");
     checkpanic asbClient->send(message1);
@@ -107,10 +107,10 @@ function testSendAndReceiveBatchFromQueueOperation() {
     AsbClient asbClient = new (config);
 
     log:printInfo("Creating Asb sender connection.");
-    checkpanic asbClient->createQueueSender(queuePath);
+    checkpanic asbClient->createQueueSender(queueName);
 
     log:printInfo("Creating Asb receiver connection.");
-    checkpanic asbClient->createQueueReceiver(queuePath, RECEIVEANDDELETE);
+    checkpanic asbClient->createQueueReceiver(queueName, RECEIVEANDDELETE);
 
     log:printInfo("Sending via Asb sender connection.");
     checkpanic asbClient->sendBatch(messages);
@@ -148,10 +148,10 @@ function testCompleteMessageFromQueueOperation() {
     AsbClient asbClient = new (config);
 
     log:printInfo("Creating Asb sender connection.");
-    checkpanic asbClient->createQueueSender(queuePath);
+    checkpanic asbClient->createQueueSender(queueName);
 
     log:printInfo("Creating Asb receiver connection.");
-    checkpanic asbClient->createQueueReceiver(queuePath, PEEKLOCK);
+    checkpanic asbClient->createQueueReceiver(queueName, PEEKLOCK);
 
     log:printInfo("Sending via Asb sender connection.");
     checkpanic asbClient->send(message1);
@@ -185,10 +185,10 @@ function testAbandonMessageFromQueueOperation() {
     AsbClient asbClient = new (config);
 
     log:printInfo("Creating Asb sender connection.");
-    checkpanic asbClient->createQueueSender(queuePath);
+    checkpanic asbClient->createQueueSender(queueName);
 
     log:printInfo("Creating Asb receiver connection.");
-    checkpanic asbClient->createQueueReceiver(queuePath, PEEKLOCK);
+    checkpanic asbClient->createQueueReceiver(queueName, PEEKLOCK);
 
     log:printInfo("Sending via Asb sender connection.");
     checkpanic asbClient->send(message1);
@@ -230,10 +230,10 @@ function testDeadletterMessageFromQueueOperation() {
     AsbClient asbClient = new (config);
 
     log:printInfo("Creating Asb sender connection.");
-    checkpanic asbClient->createQueueSender(queuePath);
+    checkpanic asbClient->createQueueSender(queueName);
 
     log:printInfo("Creating Asb receiver connection.");
-    checkpanic asbClient->createQueueReceiver(queuePath, PEEKLOCK);
+    checkpanic asbClient->createQueueReceiver(queueName, PEEKLOCK);
 
     log:printInfo("Sending via Asb sender connection.");
     checkpanic asbClient->send(message1);
@@ -267,10 +267,10 @@ function testDeferMessageFromQueueOperation() {
     AsbClient asbClient = new (config);
 
     log:printInfo("Creating Asb sender connection.");
-    checkpanic asbClient->createQueueSender(queuePath);
+    checkpanic asbClient->createQueueSender(queueName);
 
     log:printInfo("Creating Asb receiver connection.");
-    checkpanic asbClient->createQueueReceiver(queuePath, PEEKLOCK);
+    checkpanic asbClient->createQueueReceiver(queueName, PEEKLOCK);
 
     log:printInfo("Sending via Asb sender connection.");
     checkpanic asbClient->send(message1);
@@ -310,10 +310,10 @@ function testSendAndReceiveMessageFromSubscriptionOperation() {
     AsbClient asbClient = new (config);
 
     log:printInfo("Creating Asb sender connection.");
-    checkpanic asbClient->createTopicSender(topicPath);
+    checkpanic asbClient->createTopicSender(topicName);
 
     log:printInfo("Creating Asb receiver connection.");
-    checkpanic asbClient->createSubscriptionReceiver(subscriptionPath1, RECEIVEANDDELETE);
+    checkpanic asbClient->createSubscriptionReceiver(topicName, subscriptionName1, RECEIVEANDDELETE);
 
     log:printInfo("Sending via Asb sender connection.");
     checkpanic asbClient->send(message1);
@@ -346,10 +346,10 @@ function testSendAndReceiveBatchFromSubscriptionOperation() {
     AsbClient asbClient = new (config);
 
     log:printInfo("Creating Asb sender connection.");
-    checkpanic asbClient->createTopicSender(topicPath);
+    checkpanic asbClient->createTopicSender(topicName);
 
     log:printInfo("Creating Asb receiver connection.");
-    checkpanic asbClient->createSubscriptionReceiver(subscriptionPath1, RECEIVEANDDELETE);
+    checkpanic asbClient->createSubscriptionReceiver(topicName, subscriptionName1, RECEIVEANDDELETE);
 
     log:printInfo("Sending via Asb sender connection.");
     checkpanic asbClient->sendBatch(messages);
@@ -386,10 +386,10 @@ function testCompleteMessageFromSubscriptionOperation() {
     AsbClient asbClient = new (config);
 
     log:printInfo("Creating Asb sender connection.");
-    checkpanic asbClient->createTopicSender(topicPath);
+    checkpanic asbClient->createTopicSender(topicName);
 
     log:printInfo("Creating Asb receiver connection.");
-    checkpanic asbClient->createSubscriptionReceiver(subscriptionPath1, PEEKLOCK);
+    checkpanic asbClient->createSubscriptionReceiver(topicName, subscriptionName1, PEEKLOCK);
 
     log:printInfo("Sending via Asb sender connection.");
     checkpanic asbClient->send(message1);
@@ -423,10 +423,10 @@ function testAbandonMessageFromSubscriptionOperation() {
     AsbClient asbClient = new (config);
 
     log:printInfo("Creating Asb sender connection.");
-    checkpanic asbClient->createTopicSender(topicPath);
+    checkpanic asbClient->createTopicSender(topicName);
 
     log:printInfo("Creating Asb receiver connection.");
-    checkpanic asbClient->createSubscriptionReceiver(subscriptionPath1, PEEKLOCK);
+    checkpanic asbClient->createSubscriptionReceiver(topicName, subscriptionName1, PEEKLOCK);
 
     log:printInfo("Sending via Asb sender connection.");
     checkpanic asbClient->send(message1);
@@ -466,10 +466,10 @@ function testDeadletterMessageFromSubscriptionOperation() {
     AsbClient asbClient = new (config);
 
     log:printInfo("Creating Asb sender connection.");
-    checkpanic asbClient->createTopicSender(topicPath);
+    checkpanic asbClient->createTopicSender(topicName);
 
     log:printInfo("Creating Asb receiver connection.");
-    checkpanic asbClient->createSubscriptionReceiver(subscriptionPath1, PEEKLOCK);
+    checkpanic asbClient->createSubscriptionReceiver(topicName, subscriptionName1, PEEKLOCK);
 
     log:printInfo("Sending via Asb sender connection.");
     checkpanic asbClient->send(message1);
@@ -503,10 +503,10 @@ function testDeferMessageFromSubscriptionOperation() {
     AsbClient asbClient = new (config);
 
     log:printInfo("Creating Asb sender connection.");
-    checkpanic asbClient->createTopicSender(topicPath);
+    checkpanic asbClient->createTopicSender(topicName);
 
     log:printInfo("Creating Asb receiver connection.");
-    checkpanic asbClient->createSubscriptionReceiver(subscriptionPath1, PEEKLOCK);
+    checkpanic asbClient->createSubscriptionReceiver(topicName, subscriptionName1, PEEKLOCK);
 
     log:printInfo("Sending via Asb sender connection.");
     checkpanic asbClient->send(message1);

--- a/asb-native/pom.xml
+++ b/asb-native/pom.xml
@@ -81,13 +81,13 @@
         <dependency>
             <groupId>org.ballerinalang</groupId>
             <artifactId>ballerina-runtime</artifactId>
-            <version>2.0.0-alpha7-20210403-234900-bdd55df1</version>
+            <version>2.0.0-alpha8-20210423-135000-530658ec</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.ballerinalang</groupId>
             <artifactId>ballerina-lang</artifactId>
-            <version>2.0.0-alpha7-20210403-234900-bdd55df1</version>
+            <version>2.0.0-alpha8-20210423-135000-530658ec</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/asb-native/pom.xml
+++ b/asb-native/pom.xml
@@ -23,7 +23,7 @@
 
     <groupId>org.ballerinalang</groupId>
     <artifactId>asb-native</artifactId>
-    <version>1.0.1</version>
+    <version>1.0.2</version>
 
     <packaging>jar</packaging>
     <properties>

--- a/asb-native/pom.xml
+++ b/asb-native/pom.xml
@@ -81,13 +81,13 @@
         <dependency>
             <groupId>org.ballerinalang</groupId>
             <artifactId>ballerina-runtime</artifactId>
-            <version>2.0.0-alpha4</version>
+            <version>2.0.0-alpha7-20210403-234900-bdd55df1</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.ballerinalang</groupId>
             <artifactId>ballerina-lang</artifactId>
-            <version>2.0.0-alpha4</version>
+            <version>2.0.0-alpha7-20210403-234900-bdd55df1</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/asb-native/src/main/java/org/ballerinalang/asb/ASBConstants.java
+++ b/asb-native/src/main/java/org/ballerinalang/asb/ASBConstants.java
@@ -32,7 +32,7 @@ public class ASBConstants {
     // Asb package name constant fields
     public static final String ORG_NAME = "ballerinax";
     public static final String ASB = "asb";
-    public static final String ASB_VERSION = "0.1.2";
+    public static final String ASB_VERSION = "0.1.3";
     public static final Module PACKAGE_ID_ASB = new Module(ORG_NAME, ASB, ASB_VERSION);
     public static final String PACKAGE_ASB_FQN =
             ORG_NAME + ORG_NAME_SEPARATOR + ASB + VERSION_SEPARATOR + ASB_VERSION;
@@ -84,6 +84,7 @@ public class ASBConstants {
 
     public static final BString QUEUE_NAME = StringUtils.fromString("entityPath");
     public static final BString CONNECTION_STRING = StringUtils.fromString("connectionString");
+    public static final BString RECEIVE_MODE = StringUtils.fromString("receiveMode");
     public static final String CONNECTION_NATIVE_OBJECT = "asb_connection_object";
 
     public static final String SERVICE_CONFIG = "ServiceConfig";

--- a/asb-native/src/main/java/org/ballerinalang/asb/MessageDispatcher.java
+++ b/asb-native/src/main/java/org/ballerinalang/asb/MessageDispatcher.java
@@ -109,6 +109,25 @@ public class MessageDispatcher {
     }
 
     /**
+     * Get receive mode from annotation configuration attached to the service.
+     *
+     * @param service Ballerina service instance.
+     * @return Connection string from annotation configuration attached to the service.
+     */
+    public static String getReceiveModeFromConfig(BObject service) {
+        BMap serviceConfig = (BMap) ((AnnotatableType) service.getType())
+                .getAnnotation(StringUtils.fromString(ASBConstants.PACKAGE_ASB_FQN + ":"
+                        + ASBConstants.SERVICE_CONFIG));
+        @SuppressWarnings(ASBConstants.UNCHECKED)
+        BMap<BString, Object> queueConfig =
+                (BMap) serviceConfig.getMapValue(ASBConstants.ALIAS_QUEUE_CONFIG);
+        if (queueConfig.getStringValue(RECEIVE_MODE) != null) {
+            return queueConfig.getStringValue(RECEIVE_MODE).getValue();
+        }
+        return PEEKLOCK;
+    }
+
+    /**
      * Start receiving messages asynchronously and dispatch the messages to the attached service.
      *
      * @param listener Ballerina listener object.
@@ -148,11 +167,11 @@ public class MessageDispatcher {
                     pumpMessage(receiver, executorService);
                 } else {
                     handleDispatch(message);
-                    try {
-                        receiver.complete(message.getLockToken());
-                    } catch (Exception e) {
-                        return ASBUtils.returnErrorValue(e.getMessage());
-                    }
+//                    try {
+//                        receiver.complete(message.getLockToken());
+//                    } catch (Exception e) {
+//                        return ASBUtils.returnErrorValue(e.getMessage());
+//                    }
                     pumpMessage(receiver, executorService);
                     return null;
                 }


### PR DESCRIPTION
## Purpose
> Current Azure Service Bus connector implementation is in SLAlpha 4. This PR migrate the current implementation to SLAlpha 5. Apart from these the connector was revamped to address the following issues.

- Although the client provide support, listener doesn't have support for complete, abandon, deadletter, defer, receiveDeferred, renewLock, setPrefetchCount messages. 
- Listener doesn't  provide message receive mode as a configurable variable. 
- ASB client should revamp it's sender creation & receiver creation operations to support multiple queue/topic/subscription connections in a single ASB client.

Resolves https://github.com/wso2-enterprise/choreo/issues/3748
Resolves https://github.com/wso2-enterprise/choreo/issues/3763

## Goals
> Improve the Azure service bus connector to support Choreo UI and accurately handle high level messaging concepts and to improve listener capability. Migrate the connector to SLAlpha5.

## Approach
> Revamp the listener with the following changes

- Provide operations in the listener to support complete, abandon, deadletter, defer, receiveDeferred, renewLock, setPrefetchCount messages. 
- Provide receive mode as a configurable variable in the listener configuration. 
- Revamp sender creation & receiver creation operations to support multiple queue/topic/subscription connections in a single ASB client by returning a handle of the connection.
- Provide this handle as a required parameter in each connector client operation.
- Migrate to SLAlpha5.
- Update samples & documentation.


## User stories
> N/A

## Release note
> 
- Provide listener operations: complete, abandon, deadletter, defer, receiveDeferred, renewLock, setPrefetchCount messages. 
- Provide receive mode as a configurable variable in the listener configuration. Default mode is PEEKLOCK.
- Revamp sender creation & receiver creation operations to support multiple queue/topic/subscription connections in a single ASB client by returning a handle of the connection (queueSender/topicSender/queueReceiver/subscriptionReceiver).
- Provide the connection (queueSender/topicSender/queueReceiver/subscriptionReceiver) of type handle as a required parameter in each connector client operation.

## Documentation
> https://github.com/RolandHewage/module-ballerinax-azure-service-bus/tree/alpha5#readme

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > Done
 - Integration tests
   > Done

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> https://github.com/RolandHewage/module-ballerinax-azure-service-bus/tree/alpha5/asb-ballerina/samples

## Related PRs
> N/A

## Migrations (if applicable)
> Alpha 5 Migration

## Test environment
> 
SLAlpha 5
JDK 11
Ubuntu 20.04
Service Bus Ballerina Connector Version 0.1.2
Latest stable version of azure-servicebus SDK (v3.5.1)
 
## Learning
> https://github.com/Azure/azure-service-bus/tree/master/samples/Java/azure-servicebus
https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-python-how-to-use-topics-subscriptions