### PR TITLE
Change ballerina action to @slalpha5 github workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
         
       # Build Ballerina Project
       - name: Ballerina Build
-        uses: ballerina-platform/ballerina-action/@master
+        uses: ballerina-platform/ballerina-action/@slalpha5
         with:
           args:
             build -c ./asb-ballerina

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -39,7 +39,7 @@ jobs:
         
       # Build Ballerina Project
       - name: Ballerina Build
-        uses: ballerina-platform/ballerina-action/@master
+        uses: ballerina-platform/ballerina-action/@slalpha5
         with:
           args:
             build -c ./asb-ballerina

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
 
       # Build Ballerina Project
       - name: Ballerina Build
-        uses: ballerina-platform/ballerina-action/@master
+        uses: ballerina-platform/ballerina-action/@slalpha5
         with:
           args:
             build -c --skip-tests ./asb-ballerina
@@ -56,7 +56,7 @@ jobs:
 
       # Push to Ballerina Central
       - name: Ballerina Push
-        uses: ballerina-platform/ballerina-action/@master
+        uses: ballerina-platform/ballerina-action/@slalpha5
         with:
           args:
             push


### PR DESCRIPTION
## Purpose
Change the ballerina action to `@slalpha5` in github workflow yaml files.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
JDK 11
Ballerina SLAlpha5
