### PR TITLE
Ignore CI workflow in automated/dependency_version_update branch 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,10 @@ name: CI
 
 # Controls when the action will run.
 # Triggers the workflow on push.
-on: [push]
+on:
+  push:
+    branches-ignore:
+      - "automated/dependency_version_update"
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:


### PR DESCRIPTION
## Purpose
Since the github workflows are triggered on push and on pull request, when the ballerina bot tries to update ballerina lang version, both workflows are run concurrently and test cases fail.
So, CI workflow triggered on push is ignored for ballerina bot. Still the PR workflow will run.

## Goals
- Ignore CI workflow in automated/dependency_version_update branch

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
JDK 11
Ballerina SLBeta2
