### PR TITLE
[SLBeta3] Use major version to create Module object

### DIFF
--- a/asb-native/src/main/java/org/ballerinalang/asb/ASBConstants.java
+++ b/asb-native/src/main/java/org/ballerinalang/asb/ASBConstants.java
@@ -33,7 +33,8 @@ public class ASBConstants {
     public static final String ORG_NAME = "ballerinax";
     public static final String ASB = "asb";
     public static final String ASB_VERSION = "0.1.4-SNAPSHOT";
-    public static final Module PACKAGE_ID_ASB = new Module(ORG_NAME, ASB, ASB_VERSION);
+    public static final String ASB_MAJOR_VERSION = ASB_VERSION.split("\\.")[0];
+    public static final Module PACKAGE_ID_ASB = new Module(ORG_NAME, ASB, ASB_MAJOR_VERSION);
     public static final String PACKAGE_ASB_FQN =
             ORG_NAME + ORG_NAME_SEPARATOR + ASB + VERSION_SEPARATOR + ASB_VERSION;
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 org.gradle.caching=true
 group=org.ballerinalang.azure.servicebus
 version=0.1.4-SNAPSHOT
-ballerinaLangVersion=2.0.0-beta.3-20210819-105900-12ae88f7
+ballerinaLangVersion=2.0.0-beta.3-20210821-093200-e064dcef


### PR DESCRIPTION
## Purpose
- Fix https://github.com/wso2-enterprise/choreo/issues/7857
- Use major version to create Module object. 
   Reason for doing this is [this change](https://github.com/ballerina-platform/ballerina-lang/commit/ceb2009fa81162ce7c6640c38f1237706d032bae) happened in io.ballerina.runtime.api.Module Class from SLBeta3.
- Bump ballerinaLang version to the latest.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
JDK 11
SLBeta3
 
## Learning
From SLBeta3 onwards, when we create a io.ballerina.runtime.api.Module object, we have to use the major version instead of the full version.
This is because of [this change](https://github.com/ballerina-platform/ballerina-lang/commit/ceb2009fa81162ce7c6640c38f1237706d032bae).