### PR TITLE
Fix warning messages for not explicitly returning a value

### DIFF
--- a/asb-ballerina/messageReceiver.bal
+++ b/asb-ballerina/messageReceiver.bal
@@ -55,7 +55,8 @@ public isolated client class MessageReceiver {
         if message is Message {
             check self.mapContentType(message);
             return message;
-        }       
+        }  
+        return;     
     }
 
     # Receive batch of messages from queue or subscription.
@@ -155,6 +156,7 @@ public isolated client class MessageReceiver {
             check self.mapContentType(message);
             return message;
         } 
+        return;
     }
 
     # The operation renews lock on a message in a queue or subscription based on messageLockToken.


### PR DESCRIPTION
# Description

Fix the following warning messages in daily builds

```
WARNING [messageReceiver.bal:(53:74,53:88)] this function should explicitly return a value
WARNING [messageReceiver.bal:(152:92,152:106)] this function should explicitly return a value
```

Fixes # ([issue](https://github.com/ballerina-platform/ballerina-extended-library/issues/194))

One line release note: 
- Fix warning messages for not explicitly returning a value

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

**Test Configuration**:
* Ballerina Version: SLBeta5
* Operating System: Ubuntu 20.4
* Java SDK: 11

# Checklist:

### Security checks
 - [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? 
 - [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? 
