### PR TITLE
Prepare for 2.3.0 release of the connector

### DIFF
--- a/.github/workflows/dev-stg-release.yml
+++ b/.github/workflows/dev-stg-release.yml
@@ -37,7 +37,7 @@ jobs:
           ./gradlew build
           
       - name: Ballerina Build
-        uses: ballerina-platform/ballerina-action/@master
+        uses: ballerina-platform/ballerina-action@2201.0.3
         with:
           args:
             pack ./asb-ballerina
@@ -46,7 +46,7 @@ jobs:
           
       - name: Push to Staging
         if: github.event.inputs.bal_central_environment == 'STAGE'
-        uses: ballerina-platform/ballerina-action/@master
+        uses: ballerina-platform/ballerina-action@2201.0.3
         with:
           args:
             push
@@ -57,7 +57,7 @@ jobs:
           
       - name: Push to Dev
         if: github.event.inputs.bal_central_environment == 'DEV'
-        uses: ballerina-platform/ballerina-action/@master
+        uses: ballerina-platform/ballerina-action@2201.0.3
         with:
           args:
             push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
 
       # Build Ballerina Project
       - name: Ballerina Build
-        uses: ballerina-platform/ballerina-action/@master
+        uses: ballerina-platform/ballerina-action@2201.0.3
         with:
           args:
             pack ./asb-ballerina
@@ -56,7 +56,7 @@ jobs:
 
       # Push to Ballerina Central
       - name: Ballerina Push
-        uses: ballerina-platform/ballerina-action/@master
+        uses: ballerina-platform/ballerina-action@2201.0.3
         with:
           args:
             push

--- a/asb-ballerina/Ballerina.toml
+++ b/asb-ballerina/Ballerina.toml
@@ -2,7 +2,7 @@
 distribution = "2201.0.0"
 org = "ballerinax"
 name = "asb"
-version = "2.2.1"
+version = "2.3.0"
 license= ["Apache-2.0"]
 authors = ["Ballerina"]
 keywords = ["IT Operations/Message Brokers", "Cost/Paid", "Vendor/Microsoft"]
@@ -13,8 +13,8 @@ repository = "https://github.com/ballerina-platform/module-ballerinax-azure-serv
 observabilityIncluded = true
 
 [[platform.java11.dependency]]
-path = "../asb-native/build/libs/asb-native-2.2.1.jar"
+path = "../asb-native/build/libs/asb-native-2.3.0.jar"
 groupId = "org.ballerinax"
 artifactId = "asb-native"
 module = "asb-native" 
-version = "2.2.1"
+version = "2.3.0"

--- a/asb-ballerina/Dependencies.toml
+++ b/asb-ballerina/Dependencies.toml
@@ -95,7 +95,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "asb"
-version = "2.2.1"
+version = "2.3.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "log"},

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 org.gradle.caching=true
 group=org.ballerinax.azure.servicebus
-version=2.2.1
+version=2.3.0
 ballerinaLangVersion=2201.0.3


### PR DESCRIPTION
# Description
- Bump connector version to `2.3.0`
- Change ballerina-action version to `2201.0.3` in release workflows.