### PR TITLE
set a default (text/plain) in content type in message

### DIFF
--- a/asb-ballerina/message.bal
+++ b/asb-ballerina/message.bal
@@ -35,7 +35,7 @@ public type Message record {|
     @display {label: "Body"}
     string|xml|json|byte[] body;
     @display {label: "Content Type"}
-    string contentType?;
+    string contentType = TEXT;
     @display {label: "Message Id"}
     string messageId?;
     @display {label: "To"}


### PR DESCRIPTION
# Description

set a default (text/plain) for a content type in the `Message` record

PR https://github.com/wso2-enterprise/choreo/issues/16630

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# Checklist:

### Security checks
 - [X] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? 
 - [X] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? 
