### PR TITLE
Add maxAutoLockRenewDuration configuration to receiver client3.x.x

### DIFF
--- a/asb-ballerina/commons.bal
+++ b/asb-ballerina/commons.bal
@@ -30,8 +30,8 @@ public const BYTE_ARRAY = "application/octet-stream";
 // Azure Service Bus Client API Record Types.
 
 # Configurations used to create an `asb:Connection`.
-#
-# + connectionString - Service bus connection string with Shared Access Signatures
+# 
+# + connectionString - Service bus connection string with Shared Access Signatures  
 #                      ConnectionString format: 
 #                      Endpoint=sb://namespace_DNS_Name;EntityPath=EVENT_HUB_NAME;
 #                      SharedAccessKeyName=SHARED_ACCESS_KEY_NAME;SharedAccessKey=SHARED_ACCESS_KEY or  
@@ -41,15 +41,19 @@ public const BYTE_ARRAY = "application/octet-stream";
 #                   determined by the entityType field. The actual configuration details are stored in either a 
 #                   TopicSubsConfig or a QueueConfig record  
 # + receiveMode - This field holds the receive modes(RECEIVE_AND_DELETE/PEEK_LOCK) for the connection. The receive mode determines how messages are 
-#                 retrieved from the entity. The default value is PEEK_LOCK
+# retrieved from the entity. The default value is PEEK_LOCK  
+# + maxAutoLockRenewDuration - Max lock renewal duration under PEEK_LOCK mode. Setting to 0 disables auto-renewal (default). 
+#                              For RECEIVE_AND_DELETE mode, auto-renewal is disabled.
 @display {label: "Receiver Connection Config"}
 public type ASBServiceReceiverConfig record {
-    @display {label: "Entity Configuration"}
-    TopicSubsConfig|QueueConfig entityConfig;
     @display {label: "ConnectionString"}
     string connectionString;
+    @display {label: "Entity Configuration"}
+    TopicSubsConfig|QueueConfig entityConfig;
     @display {label: "Receive Mode"}
     ReceiveMode receiveMode = PEEK_LOCK;
+    @display {label: "Max Auto Lock Renew Duration"}
+    int maxAutoLockRenewDuration = 0;
 };
 
 # This record holds the configuration details of a topic and its associated subscription in Azure Service Bus

--- a/asb-ballerina/messageReceiver.bal
+++ b/asb-ballerina/messageReceiver.bal
@@ -26,6 +26,7 @@ public isolated client class MessageReceiver {
     private string subscriptionName;
     private string topicName;
     private string receiveMode;
+    private int maxAutoLockRenewDuration;
     private LogLevel logLevel;
     final handle receiverHandle;
 
@@ -50,10 +51,11 @@ public isolated client class MessageReceiver {
         }
         
         self.receiveMode = config.receiveMode;
+        self.maxAutoLockRenewDuration = config.maxAutoLockRenewDuration;
         self.logLevel = customConfiguration.logLevel;
         self.receiverHandle = check initMessageReceiver(java:fromString(self.connectionString), 
         java:fromString(self.queueName),java:fromString(self.topicName), java:fromString(self.subscriptionName), 
-        java:fromString(self.receiveMode), java:fromString(self.logLevel));
+        java:fromString(self.receiveMode), self.maxAutoLockRenewDuration, java:fromString(self.logLevel));
     }
 
     # Receive message from queue or subscription.
@@ -188,10 +190,10 @@ public isolated client class MessageReceiver {
 }
 
 isolated function initMessageReceiver(handle connectionString, handle queueName, handle topicName, 
-        handle subscriptionName, handle receiveMode, handle isLogActive) returns handle|error = @java:Constructor {
+        handle subscriptionName, handle receiveMode, int maxAutoLockRenewDuration, handle isLogActive) returns handle|error = @java:Constructor {
     'class: "org.ballerinax.asb.receiver.MessageReceiver",
-    paramTypes: ["java.lang.String", "java.lang.String", "java.lang.String", "java.lang.String", "java.lang.String"
-    ,"java.lang.String"]
+    paramTypes: ["java.lang.String", "java.lang.String", "java.lang.String", "java.lang.String", "java.lang.String",
+                 "long","java.lang.String"]
 } external;
 
 isolated function receive(handle receiverHandle, MessageReceiver endpointClient, int? serverWaitTime) returns Message|error? = @java:Method {

--- a/asb-native/src/main/java/org/ballerinax/asb/receiver/MessageReceiver.java
+++ b/asb-native/src/main/java/org/ballerinax/asb/receiver/MessageReceiver.java
@@ -68,13 +68,15 @@ public class MessageReceiver {
      * @param topicName        Topic Name
      * @param subscriptionName Subscription Name
      * @param receiveMode      Receive Mode as PeekLock or Receive&Delete.
+     * @param maxAutoLockRenewDuration Max lock renewal duration under Peek Lock mode. Setting to 0 disables auto-renewal. 
+     *                                  For RECEIVE_AND_DELETE mode, auto-renewal is disabled.
      * @throws ServiceBusException  on failure initiating IMessage Receiver in Azure
      *                              Service Bus instance.
      * @throws InterruptedException on failure initiating IMessage Receiver due to
      *                              thread interruption.
      */
     public MessageReceiver(String connectionString, String queueName, String topicName, String subscriptionName,
-            String receiveMode, String logLevel)
+            String receiveMode, long maxAutoLockRenewDuration, String logLevel)
             throws ServiceBusException, InterruptedException {
         log.setLevel(Level.toLevel(logLevel, Level.OFF));
         ServiceBusReceiverClientBuilder receiverClientBuilder = new ServiceBusClientBuilder()
@@ -91,6 +93,7 @@ public class MessageReceiver {
                 this.receiver = receiverClientBuilder
                         .receiveMode(ServiceBusReceiveMode.PEEK_LOCK)
                         .queueName(queueName)
+                        .maxAutoLockRenewDuration(Duration.ofSeconds(maxAutoLockRenewDuration))
                         .buildClient();
             }
         } else if (!subscriptionName.isEmpty() && !topicName.isEmpty()) {
@@ -106,6 +109,7 @@ public class MessageReceiver {
                         .receiveMode(ServiceBusReceiveMode.PEEK_LOCK)
                         .topicName(topicName)
                         .subscriptionName(subscriptionName)
+                        .maxAutoLockRenewDuration(Duration.ofSeconds(maxAutoLockRenewDuration))
                         .buildClient();
             }
         }


### PR DESCRIPTION
# Description

Add `maxAutoLockRenewDuration` configuration. 

Related issue : https://github.com/wso2-enterprise/choreo/issues/18792


One line release note: 
-  Add maxAutoLockRenewDuration configuration to receiver client

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update



**Test Configuration**:
* Ballerina Version: 2201.3.1
* Operating System: Mac OS X


# Checklist:

### Security checks
 - [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? 
 - [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? 
