### PR TITLE
[2201.3.x] Update value type of the application properties to `map<anydata>` in `asb:Message`

### DIFF
--- a/asb-ballerina/Ballerina.toml
+++ b/asb-ballerina/Ballerina.toml
@@ -2,7 +2,7 @@
 distribution = "2201.3.1"
 org = "ballerinax"
 name = "asb"
-version = "3.0.3"
+version = "3.0.4"
 license= ["Apache-2.0"]
 authors = ["Ballerina"]
 keywords = ["IT Operations/Message Brokers", "Cost/Paid", "Vendor/Microsoft"]
@@ -13,9 +13,9 @@ repository = "https://github.com/ballerina-platform/module-ballerinax-azure-serv
 observabilityIncluded = true
 
 [[platform.java11.dependency]]
-path = "../asb-native/build/libs/asb-native-3.0.3.jar"
+path = "../asb-native/build/libs/asb-native-3.0.4.jar"
 groupId = "org.ballerinax"
 artifactId = "asb-native"
 module = "asb-native" 
-version = "3.0.3"
+version = "3.0.4"
 

--- a/asb-ballerina/Dependencies.toml
+++ b/asb-ballerina/Dependencies.toml
@@ -104,7 +104,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "asb"
-version = "3.0.3"
+version = "3.0.4"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "log"},

--- a/asb-ballerina/message.bal
+++ b/asb-ballerina/message.bal
@@ -91,5 +91,5 @@ public type Message record {|
 @display {label: "Application Properties"}
 public type ApplicationProperties record {|
     @display {label: "Properties"}
-    map<any> properties?;
+    map<byte[]> properties?;
 |};

--- a/asb-ballerina/message.bal
+++ b/asb-ballerina/message.bal
@@ -91,5 +91,5 @@ public type Message record {|
 @display {label: "Application Properties"}
 public type ApplicationProperties record {|
     @display {label: "Properties"}
-    map<byte[]> properties?;
+    map<anydata> properties?;
 |};

--- a/asb-ballerina/tests/asb_test.bal
+++ b/asb-ballerina/tests/asb_test.bal
@@ -31,7 +31,7 @@ string stringContent = "This is ASB connector test-Message Body";
 byte[] byteContent = stringContent.toBytes();
 json jsonContent = {name: "wso2", color: "orange", price: 5.36};
 byte[] byteContentFromJson = jsonContent.toJsonString().toBytes();
-map<any> properties = {a: "propertyValue1", b: "propertyValue2", c: 1, d: "true", f: 1.345, s: false, k:1020202, g: jsonContent};
+map<anydata> properties = {a: "propertyValue1", b: "propertyValue2", c: 1, d: "true", f: 1.345, s: false, k:1020202, g: jsonContent};
 int timeToLive = 60; // In seconds
 int serverWaitTime = 60; // In seconds
 int maxMessageCount = 2;
@@ -94,7 +94,7 @@ function testSendAndReceiveMessageFromQueueOperation() returns error? {
     if (messageReceived is Message) {
         var result = check messageReceiver->complete(messageReceived);
         test:assertEquals(result, (), msg = "Complete message not successful.");
-        float mapValue = <float> check getApplicationPropertyByName(messageReceived, "f");
+        float mapValue = check getApplicationPropertyByName(messageReceived, "f").ensureType();
         test:assertEquals(mapValue, <float>properties["f"], "Retrieving application properties failed");
     } else if (messageReceived is ()) {
         test:assertFail("No message in the queue.");

--- a/asb-ballerina/utils.bal
+++ b/asb-ballerina/utils.bal
@@ -19,8 +19,8 @@
 # + message - Represents a message that contains application properties
 # + name - Represents the name of the application property that the user wants to retrieve.
 # + return - Returns null if the requested property does not exist
-public isolated function getApplicationPropertyByName(Message message, string name) returns any|error? {
+public isolated function getApplicationPropertyByName(Message message, string name) returns anydata|error? {
         ApplicationProperties applicationPropertiesResult = check message.applicationProperties.ensureType();
-        map<any> properties = check applicationPropertiesResult.properties.ensureType();
+        map<anydata> properties = check applicationPropertiesResult.properties.ensureType();
         return properties[name];
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 org.gradle.caching=true
 group=org.ballerinax.azure.servicebus
-version=3.0.3
+version=3.0.4
 ballerinaLangVersion=2201.3.1


### PR DESCRIPTION
# Description
> $subject

As per the discussion we had with @abeykoon and @SanduDS I have sent the PR on behalf of Connector team.

Referred to service bus documentation [1] for this change.

[1] - https://learn.microsoft.com/en-us/rest/api/servicebus/message-headers-and-properties#message-properties

Fixes [#19457](https://github.com/wso2-enterprise/choreo/issues/19457)

One line release note: 
- Update value type of the application-properties in `asb:Message`

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Test Configuration**:
* Ballerina Version: Ballerina 2201.3.x
* Operating System: Ubuntu
* Java SDK: Open JDK 11

# Checklist:

### Security checks
 - [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? 
 - [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? 
