### PR TITLE
[2201.4.x] Fix message count inreceiveBatch() API when there are less messages than the requested count

### DIFF
--- a/asb-ballerina/Ballerina.toml
+++ b/asb-ballerina/Ballerina.toml
@@ -2,7 +2,7 @@
 distribution = "2201.4.1"
 org = "ballerinax"
 name = "asb"
-version = "3.3.0"
+version = "3.3.1"
 license= ["Apache-2.0"]
 authors = ["Ballerina"]
 keywords = ["IT Operations/Message Brokers", "Cost/Paid", "Vendor/Microsoft"]
@@ -13,9 +13,9 @@ repository = "https://github.com/ballerina-platform/module-ballerinax-azure-serv
 observabilityIncluded = true
 
 [[platform.java11.dependency]]
-path = "../asb-native/build/libs/asb-native-3.3.0.jar"
+path = "../asb-native/build/libs/asb-native-3.3.1.jar"
 groupId = "org.ballerinax"
 artifactId = "asb-native"
 module = "asb-native" 
-version = "3.3.0"
+version = "3.3.1"
 

--- a/asb-ballerina/tests/asb_test.bal
+++ b/asb-ballerina/tests/asb_test.bal
@@ -206,11 +206,15 @@ function testSendAndReceiveBatchFromQueueOperation() returns error? {
     log:printInfo("Sending via Asb sender.");
     check messageSender->sendBatch(messages);
 
+    // Here we set the batch size to be more than the number of messages sent. 
+    // This is to validate whether the received message count is always same as the sent count, 
+    // even when the expected count is larger than the sent count
     log:printInfo("Receiving from Asb receiver.");
-    MessageBatch|error? messageReceived = messageReceiver->receiveBatch(maxMessageCount);
+    MessageBatch|error? messageReceived = messageReceiver->receiveBatch(messages.length() + 5);
 
     if (messageReceived is MessageBatch) {
         log:printInfo(messageReceived.toString());
+        test:assertEquals(messageReceived.messages.length(), messages.length(), msg = "Sent & received message counts are not equal.");
         foreach Message message in messageReceived.messages {
             if (message.toString() != "") {
                 string msg = check string:fromBytes(<byte[]>message.body);

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.caching=true
 group=org.ballerinax.azure.servicebus
-version=3.3.0
+version=3.3.1
 ballerinaLangVersion=2201.4.1
 
 azureServiceBusVersion=7.13.1


### PR DESCRIPTION
# Description
$subject.

Fixes https://github.com/ballerina-platform/ballerina-extended-library/issues/510

One line release note: 
- Fixed message count in`receiveBatch()` API when there are less messages than the requested count.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Ballerina Version:
* Operating System:
* Java SDK: 

# Checklist:

### Security checks
 - [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? 
 - [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? 
