### PR TITLE
Add management operations related to service bus

### DIFF
--- a/asb-ballerina/management_client.bal
+++ b/asb-ballerina/management_client.bal
@@ -1,0 +1,82 @@
+// Copyright (c) 2023 WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/jballerina.java as java;
+
+# Ballerina Service Bus connector provides the capability to access Azure Service Bus SDK.
+# Service Bus API provides data access to highly reliable queues and publish/subscribe topics of Azure Service Bus with deep feature capabilities.
+@display {label: "Azure Service Bus Message Manager", iconPath: "resources/asb.svg"}
+public isolated client class ManagementClient {
+
+    final string connectionString;
+    final handle managementClientHandle;
+
+    # Initializes the connector. During initialization you can pass the [Shared Access Signature (SAS) authentication credentials](https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-sas)
+    # Create an [Azure account](https://docs.microsoft.com/en-us/learn/modules/create-an-azure-account/) and 
+    # obtain tokens following [this guide](https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-quickstart-portal#get-the-connection-string). 
+    # Configure the connection string to have the [required permission](https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-sas).
+    # 
+    # + connectionString - Connection String of Azure service bus
+    public isolated function init(@display {label: "Connection String"} string connectionString) returns Error? {
+        self.connectionString = connectionString;
+        self.managementClientHandle = initManagementClient(java:fromString(self.connectionString));
+    }
+
+    // isolated remote function getNamespaceInfo() returns NamespaceInfo|error {
+    //     return check getNamespaceInfo(self.managementClientHandle); 
+    // }
+
+    // isolated remote function getMessageCountDetailsOfQueue(string entityPath) returns MessageCountDetails|error {
+    //     return check getMessageCountDetailsOfQueue(self.managementClientHandle, java:fromString(entityPath)); 
+    // }
+}
+
+isolated function initManagementClient(handle connectionString) returns handle = @java:Constructor {
+    'class: "org.ballerinax.asb.management.ManagementSource",
+    paramTypes: ["java.lang.String"]
+} external;
+
+isolated function getNamespaceInfo(handle managementClientHandle) returns NamespaceInfo|error = @java:Method {
+    'class: "org.ballerinax.asb.management.ManagementSource"
+} external;
+
+isolated function getMessageCountDetailsOfQueue(handle managementClientHandle, handle entityPath) returns MessageCountDetails|error = @java:Method {
+    'class: "org.ballerinax.asb.management.ManagementSource"
+} external;
+
+isolated function createQueue(handle managementClientHandle, handle queueName) returns QueueProperties|error = @java:Method {
+    'class: "org.ballerinax.asb.management.ManagementSource"
+} external;
+
+isolated function deleteQueue(handle managementClientHandle, handle queueName) returns error? = @java:Method {
+    'class: "org.ballerinax.asb.management.ManagementSource"
+} external;
+
+isolated function createTopic(handle managementClientHandle, handle topicName) returns TopicProperties|error = @java:Method {
+    'class: "org.ballerinax.asb.management.ManagementSource"
+} external;
+
+isolated function deleteTopic(handle managementClientHandle, handle topicName) returns error? = @java:Method {
+    'class: "org.ballerinax.asb.management.ManagementSource"
+} external;
+
+isolated function createSubscription(handle managementClientHandle, handle topicName, handle subscriptionName) returns SubscriptionProperties|error = @java:Method {
+    'class: "org.ballerinax.asb.management.ManagementSource"
+} external;
+
+isolated function deleteSubscription(handle managementClientHandle, handle topicName, handle subscriptionName) returns error? = @java:Method {
+    'class: "org.ballerinax.asb.management.ManagementSource"
+} external;

--- a/asb-ballerina/tests/asb_management_test.bal
+++ b/asb-ballerina/tests/asb_management_test.bal
@@ -1,0 +1,43 @@
+// Copyright (c) 2023, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/io;
+import ballerina/os;
+import ballerina/test;
+
+configurable string connectionString1 = os:getEnv("CONNECTION_STRING");
+
+const string QUEUE_NAME = "queue1";
+
+final ManagementClient clientEp = check new(connectionString1);
+
+@test:Config {
+    groups: ["adminClient"]
+}
+isolated function testCreateQueue() returns error? {
+    QueueProperties queueProperties = check clientEp->createQueue(QUEUE_NAME);
+    io:println(queueProperties);
+    test:assertEquals(queueProperties.topicName, QUEUE_NAME);
+    test:assertEquals(queueProperties.status, "Active");
+}
+
+@test:Config {
+    groups: ["adminClient"],
+    dependsOn: [testCreateQueue]
+}
+isolated function testTopicDeletion() returns error? {
+    check clientEp->deleteQueue(QUEUE_NAME);
+}

--- a/asb-ballerina/types.bal
+++ b/asb-ballerina/types.bal
@@ -244,6 +244,35 @@ public enum ReceiveMode {
     PEEK_LOCK = "PEEKLOCK"
 }
 
+public type NamespaceInfo record {
+    string name?;
+};
+
+public type MessageCountDetails record {
+    float activeMessageCount?;
+    float deadLetterMessageCount?;
+    float scheduledMessageCount?;
+    float transferMessageCount?;
+    float transferDeadLetterMessageCount?;
+};
+
+public type QueueProperties record {|
+    string topicName;
+    string status;
+    string userMetaData;
+|};
+
+public type TopicProperties record {|
+    string topicName;
+    string status;
+    string userMetaData;
+|};
+
+public type SubscriptionProperties record {|
+    string status;
+    string userMetaData;
+|};
+
 # Log levels
 public enum LogLevel {
     @display {label: "DEBUG"}

--- a/asb-native/build.gradle
+++ b/asb-native/build.gradle
@@ -30,6 +30,7 @@ dependencies {
     checkstyle project(':checkstyle')
     checkstyle "com.puppycrawl.tools:checkstyle:${puppycrawlCheckstyleVersion}"
     implementation group: 'com.azure', name: 'azure-messaging-servicebus', version: "${azureServiceBusVersion}"
+    implementation (group: 'com.microsoft.azure', name: 'azure-servicebus', version: '3.6.7') { transitive = false }
     implementation group: 'org.slf4j', name: 'slf4j-jdk14', version: "${slf4jVersion}"
     implementation group: 'org.ballerinalang', name: 'ballerina-lang', version: project.ballerinaLangVersion
     implementation(group: 'org.ballerinalang', name: 'ballerina-runtime', version: project.ballerinaLangVersion) { transitive = false }

--- a/asb-native/src/main/java/org/ballerinax/asb/management/ManagementSource.java
+++ b/asb-native/src/main/java/org/ballerinax/asb/management/ManagementSource.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KINDither express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.ballerinax.asb.manager;
+
+import com.azure.messaging.servicebus.ServiceBusException;
+import com.azure.messaging.servicebus.administration.MessageCountDetails;
+import com.azure.messaging.servicebus.administration.NamespaceInfo;
+import com.azure.messaging.servicebus.administration.ServiceBusAdministrationClient;
+import com.azure.messaging.servicebus.administration.ServiceBusAdministrationClientBuilder;
+import com.azure.messaging.servicebus.administration.models.QueueProperties;
+import com.azure.messaging.servicebus.administration.models.SubscriptionProperties;
+import com.azure.messaging.servicebus.administration.models.TopicProperties;
+import io.ballerina.runtime.api.creators.ValueCreator;
+import io.ballerina.runtime.api.utils.StringUtils;
+import io.ballerina.runtime.api.values.BMap;
+import io.ballerina.runtime.api.values.BString;
+import org.ballerinax.asb.util.ASBConstants;
+import org.ballerinax.asb.util.ASBErrorCreator;
+import org.ballerinax.asb.util.ModuleUtils;
+
+/**
+ * This facilitates the client operations of ASB Management client in
+ * Ballerina.
+ */
+public class ManagementSource {
+    ServiceBusAdministrationClient managementClient;
+
+    public ManagementSource(String connectionString) {
+        this.managementClient = new ServiceBusAdministrationClientBuilder()
+                                    .connectionString(connectionString).buildClient();
+    }
+
+    public Object getNamespaceInfo() {
+        try {
+            NamespaceInfo namespaceInfo = managementClient.getNamespaceInfo();
+            Object[] values = new Object[1];
+            values[0] = StringUtils.fromString(namespaceInfo.getName());
+            BMap<BString, Object> namespaceRecord =
+                    ValueCreator.createRecordValue(ModuleUtils.getModule(),
+                    ASBConstants.NAMESPACE_INFO);
+            return ValueCreator.createRecordValue(namespaceRecord, values);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return null;
+        } catch (ServiceBusException e) {
+            return ASBErrorCreator.fromASBException(e);
+        }
+    }
+
+    public Object getMessageCountDetailsOfQueue(String entityPath) {
+        try {
+            MessageCountDetails messageCountDetails =
+               managementClient.getQueueRuntimeInfo(entityPath).getMessageCountDetails();
+            Object[] values = new Object[5];
+            values[0] = messageCountDetails.getActiveMessageCount();
+            values[1] = messageCountDetails.getDeadLetterMessageCount();
+            values[2] = messageCountDetails.getScheduledMessageCount();
+            values[3] = messageCountDetails.getTransferMessageCount();
+            values[4] = messageCountDetails.getTransferDeadLetterMessageCount();
+            BMap<BString, Object> messageCountDetailsRecord =
+                    ValueCreator.createRecordValue(ModuleUtils.getModule(), ASBConstants.MESSAGE_COUNT_DETAILS);
+            return ValueCreator.createRecordValue(messageCountDetailsRecord, values);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return null;
+        } catch (ServiceBusException e) {
+            return ASBErrorCreator.fromASBException(e);
+        }
+    }
+
+    public Object createQueue(String queueName) {
+        try {
+            QueueProperties queueProperties = managementClient.createQueue(queueName);
+            BMap<BString, Object> queuePropertiesRecord =
+                    ValueCreator.createRecordValue(ModuleUtils.getModule(),
+                    ASBConstants.QUEUE_PROPERTIES);
+            return ValueCreator.createRecordValue(queuePropertiesRecord, queueProperties);
+        } catch (ServiceBusException e) {
+            return ASBErrorCreator.fromASBException(e);
+        }
+    }
+
+    public Object deleteQueue(String queueName) {
+        try {
+            managementClient.deleteQueue(queueName);
+        } catch (Exception e) {
+            return ASBErrorCreator.fromUnhandledException(e);
+        }
+        return null;
+    }
+
+    public Object createTopic(String topicName) {
+        try {
+            TopicProperties topicProperties = managementClient.createTopic(topicName);
+            BMap<BString, Object> topicPropertiesRecord =
+                    ValueCreator.createRecordValue(ModuleUtils.getModule(),
+                    ASBConstants.TOPIC_PROPERTIES);
+            return ValueCreator.createRecordValue(topicPropertiesRecord, topicProperties);
+        } catch (ServiceBusException e) {
+            return ASBErrorCreator.fromASBException(e);
+        }
+    }
+
+    public Object deleteTopic(String topicName) {
+        try {
+            managementClient.deleteTopic(topicName);
+        } catch (Exception e) {
+            return ASBErrorCreator.fromUnhandledException(e);
+        }
+        return null;
+    }
+
+    public Object createSubscription(String topicName, String subscriptionName) {
+        try {
+            SubscriptionProperties subscriptionProperties =
+                managementClient.createSubscription(topicName, subscriptionName);
+            BMap<BString, Object> subscriptionPropertiesRecord =
+                    ValueCreator.createRecordValue(ModuleUtils.getModule(),
+                    ASBConstants.SUBSCRIPTION_PROPERTIES);
+            return ValueCreator.createRecordValue(subscriptionPropertiesRecord, subscriptionProperties);
+        } catch (ServiceBusException e) {
+            return ASBErrorCreator.fromASBException(e);
+        }
+    }
+
+    public Object deleteSubscription(String topicName, String subscriptionName) {
+        try {
+            managementClient.deleteSubscription(topicName, subscriptionName);
+        } catch (Exception e) {
+            return ASBErrorCreator.fromUnhandledException(e);
+        }
+        return null;
+    }
+}

--- a/asb-native/src/main/java/org/ballerinax/asb/util/ASBConstants.java
+++ b/asb-native/src/main/java/org/ballerinax/asb/util/ASBConstants.java
@@ -97,4 +97,11 @@ public class ASBConstants {
 
     // Error constant fields
     static final String ASB_ERROR = "Error";
+
+    // Constants related to management operations
+    public static final String NAMESPACE_INFO = "NamespaceInfo";
+    public static final String MESSAGE_COUNT_DETAILS = "MessageCountDetails";
+    public static final String QUEUE_PROPERTIES = "QueueProperties";
+    public static final String TOPIC_PROPERTIES = "TopicProperties";
+    public static final String SUBSCRIPTION_PROPERTIES = "SubscriptionProperties";
 }


### PR DESCRIPTION
# Description
Add management operations related to service bus like active number of messages, active number of DLQ messages and get namespaces
Create edit and delete asb entity instances also will br added

Related to https://github.com/ballerina-platform/ballerina-extended-library/issues/516

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Test Configuration**:
* Ballerina Version: 2201.3.1
* Java SDK: Java 11

# Checklist:

### Security checks
 - [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? 
 - [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? 
