### PR TITLE
Add a flag in receiver configuration to mark Dead Letter Queue

### DIFF
--- a/asb-ballerina/constants.bal
+++ b/asb-ballerina/constants.bal
@@ -20,6 +20,7 @@ public const DEFAULT_MAX_MESSAGE_COUNT = 1;
 public const DEFAULT_SERVER_WAIT_TIME = 300; // In seconds
 public const DEFAULT_MESSAGE_LOCK_TOKEN = "00000000-0000-0000-0000-000000000000";
 const EMPTY_STRING = "";
+const DEAD_LETTER_QUEUE_PATH = "/$deadletterqueue";
 
 // Message content types
 public const TEXT = "text/plain";

--- a/asb-ballerina/receiver.bal
+++ b/asb-ballerina/receiver.bal
@@ -23,6 +23,7 @@ public isolated client class MessageReceiver {
     
     private  string connectionString;
     private string queueName;
+    private boolean isDeadLetterQueue;
     private string subscriptionName;
     private string topicName;
     private string receiveMode;
@@ -43,7 +44,11 @@ public isolated client class MessageReceiver {
             if queueConfig is error {
                 return createError(queueConfig);
             }
+            self.isDeadLetterQueue = config.isDeadLetterQueue;
             self.queueName = queueConfig.queueName;
+            if self.isDeadLetterQueue {
+                self.queueName = queueConfig.queueName + DEAD_LETTER_QUEUE_PATH;                
+            }
             self.subscriptionName = EMPTY_STRING;
             self.topicName = EMPTY_STRING;
         } else {
@@ -51,8 +56,12 @@ public isolated client class MessageReceiver {
             if topicSubsConfig is error {
                 return createError(topicSubsConfig);
             }
+            self.isDeadLetterQueue = config.isDeadLetterQueue;
             self.topicName = topicSubsConfig.topicName;
             self.subscriptionName = topicSubsConfig.subscriptionName;
+            if self.isDeadLetterQueue {
+                self.subscriptionName = topicSubsConfig.subscriptionName + DEAD_LETTER_QUEUE_PATH;                
+            }
             self.queueName = EMPTY_STRING;
         }
         self.receiveMode = config.receiveMode;

--- a/asb-ballerina/types.bal
+++ b/asb-ballerina/types.bal
@@ -114,6 +114,7 @@ public type ApplicationProperties record {|
 #                      SharedAccessKeyName=SHARED_ACCESS_KEY_NAME;SharedAccessKey=SHARED_ACCESS_KEY or  
 #                      Endpoint=sb://namespace_DNS_Name;EntityPath=EVENT_HUB_NAME;
 #                      SharedAccessSignatureToken=SHARED_ACCESS_SIGNATURE_TOKEN 
+# + isDeadLetterQueue - To mark whether it is dead letter queue
 # + entityConfig -  This field holds the configuration details of either a topic or a queue. The type of the entity is 
 #                   determined by the entityType field. The actual configuration details are stored in either a 
 #                   TopicSubsConfig or a QueueConfig record  
@@ -128,6 +129,8 @@ public type ASBServiceReceiverConfig record {
     string connectionString;
     @display {label: "Entity Configuration"}
     TopicSubsConfig|QueueConfig entityConfig;
+    @display {label: "Dead letter queue"}
+    boolean isDeadLetterQueue = false;
     @display {label: "Receive Mode"}
     ReceiveMode receiveMode = PEEK_LOCK;
     @display {label: "Max Auto Lock Renew Duration"}

--- a/asb-ballerina/types.bal
+++ b/asb-ballerina/types.bal
@@ -129,7 +129,7 @@ public type ASBServiceReceiverConfig record {
     string connectionString;
     @display {label: "Entity Configuration"}
     TopicSubsConfig|QueueConfig entityConfig;
-    @display {label: "Dead letter queue"}
+    @display {label: "Dead Letter Queue"}
     boolean isDeadLetterQueue = false;
     @display {label: "Receive Mode"}
     ReceiveMode receiveMode = PEEK_LOCK;


### PR DESCRIPTION
# Description
Add a flag in receiver configuration to mark Dead Letter Queue

Related https://github.com/ballerina-platform/ballerina-extended-library/issues/517

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Test Configuration**:
* Ballerina Version: 2201.5.0
* Operating System:
* Java SDK: 

# Checklist:

### Security checks
 - [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? 
 - [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? 
