### PR TITLE
Fix incorrect resource paths in documentations

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ from subscription, etc.
 
 For more information, go to the module(s).
 
-- [asb](asb-ballerina/Module.md)
+- [asb](ballerina/Module.md)
 
 ## Building from the source
 
@@ -46,14 +46,14 @@ Execute the commands below to build from the source.
 ```
 
 2. To build the Ballerina package:
-   Change the current directory to the asb-ballerina home directory and execute the following command.
+   Change the current directory to the ballerina home directory and execute the following command.
 
 ```shell script
     bal pack
 ```
 
 3. To run the tests after build:
-   Change the current directory to the asb-ballerina home directory and execute the following command.
+   Change the current directory to the ballerina home directory and execute the following command.
 
 ```shell script
     bal test

--- a/ballerina/Module.md
+++ b/ballerina/Module.md
@@ -183,4 +183,4 @@ asb:MessageReceiver subscriptionReceiver = check new (receiverConfig);
 
 2. Use `bal run` command to compile and run the Ballerina program.
 
-**[You can find a list of samples here](https://github.com/ballerina-platform/module-ballerinax-azure-service-bus/tree/main/asb-ballerina/samples)**
+**[You can find a list of samples here](https://github.com/ballerina-platform/module-ballerinax-azure-service-bus/tree/main/examples)**


### PR DESCRIPTION
# Description

Corrected the invalid resource paths in the documentations that were a result of a previous directory restructuring.
 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

### Security checks
 - [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? 
 - [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? 
