### PR TITLE
Fix native data retention issue

### DIFF
--- a/native/src/main/java/org/ballerinax/asb/util/ASBConstants.java
+++ b/native/src/main/java/org/ballerinax/asb/util/ASBConstants.java
@@ -44,6 +44,8 @@ public class ASBConstants {
 
     // Message constant fields
     public static final String MESSAGE_RECORD = "Message";
+    public static final String LOCK_DURATION = "LockDuration";
+    public static final String MESSAGE_MAP_RECORD = "MessageMap";
     public static final String APPLICATION_PROPERTY_TYPE = "ApplicationProperties";
     // Message content data binding errors
     public static final String XML_CONTENT_ERROR = "Error while retrieving the xml content of the message. ";

--- a/native/src/main/java/org/ballerinax/asb/util/ASBErrorCreator.java
+++ b/native/src/main/java/org/ballerinax/asb/util/ASBErrorCreator.java
@@ -22,6 +22,7 @@ import com.azure.messaging.servicebus.ServiceBusException;
 import io.ballerina.runtime.api.creators.ErrorCreator;
 import io.ballerina.runtime.api.utils.StringUtils;
 import io.ballerina.runtime.api.values.BError;
+import org.ballerinax.asb.util.exception.ExpiringMessageMapException;
 
 import static org.ballerinax.asb.util.ASBConstants.ASB_ERROR;
 import static org.ballerinax.asb.util.ModuleUtils.getModule;
@@ -54,5 +55,8 @@ public class ASBErrorCreator {
     }
     private static BError fromJavaException(String message, Throwable cause) {
         return fromBError(message, ErrorCreator.createError(cause));
+    }
+    public static BError fromExpiringMessageMapException(ExpiringMessageMapException cause) {
+        return fromJavaException(ASB_ERROR_PREFIX + cause.getMessage(), cause);
     }
 }

--- a/native/src/main/java/org/ballerinax/asb/util/ExpiringMessageMap.java
+++ b/native/src/main/java/org/ballerinax/asb/util/ExpiringMessageMap.java
@@ -1,0 +1,64 @@
+package org.ballerinax.asb.util;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static org.ballerinax.asb.util.ASBConstants.LOCK_DURATION;
+/**
+ * This class will hold auto-expire map of messages that are received from the service bus.
+ */
+public class ExpiringMessageMap {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ExpiringMessageMap.class);
+    private final Map<String, Object> map = new ConcurrentHashMap<>();
+    private Thread cleanupThread;
+
+    public void initialize() {
+        if (cleanupThread == null) {
+            cleanupThread = new Thread(() -> {
+                while (!Thread.currentThread().isInterrupted()) {
+                    removeExpiredObjects();
+                    try {
+                        Thread.sleep(3000); // Adjust the cleanup interval as needed
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    }
+                }
+            });
+            cleanupThread.setDaemon(true);
+            cleanupThread.start();
+            LOGGER.debug("Expiring message map cleanup thread started");
+        }
+    }
+
+    public void put(String key, Object value) {
+        map.put(key, value);
+    }
+
+    public Object get(String key) {
+        return map.get(key);
+    }
+
+    public void remove(String key) {
+        map.remove(key);
+    }
+
+    private void removeExpiredObjects() {
+        map.entrySet().removeIf(entry -> {
+            Map<String, Object> messageData = (Map<String, Object>) entry.getValue();
+            OffsetDateTime lockTime = (OffsetDateTime) messageData.get(LOCK_DURATION);
+            if (lockTime.isBefore(OffsetDateTime.now(ZoneOffset.UTC))) {
+                LOGGER.debug("Entry with key {} is being deleted.", entry.getKey());
+                return true;
+            }
+            return false;
+        });
+
+    }
+
+}

--- a/native/src/main/java/org/ballerinax/asb/util/exception/ExpiringMessageMapException.java
+++ b/native/src/main/java/org/ballerinax/asb/util/exception/ExpiringMessageMapException.java
@@ -1,0 +1,13 @@
+package org.ballerinax.asb.util.exception;
+
+/**
+ * ASB expiring message map error exception.
+ *
+ * @since 4.0.0
+ */
+public class ExpiringMessageMapException extends Exception {
+
+    public ExpiringMessageMapException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
# Description
To address [issue](https://github.com/ballerina-platform/ballerina-extended-library/issues/562), we propose implementing an Expiring HashMap for managing the native data associated with messages in the Azure Service Bus (ASB) Ballerina connector. This Expiring HashMap will automatically remove native data entries after a specified time(lockDuration), ensuring that native data is not accumulated in memory indefinitely..

Fixes # (issue)
https://github.com/ballerina-platform/ballerina-extended-library/issues/562

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
