### PR TITLE
Fix Native Data Retention Issue

### DIFF
--- a/ballerina/receiver.bal
+++ b/ballerina/receiver.bal
@@ -119,7 +119,7 @@ public isolated client class MessageReceiver {
         if message?.lockToken.toString() != DEFAULT_MESSAGE_LOCK_TOKEN {
             return complete(self, message);
         }
-        return createError("Failed to complete message with ID " + message?.messageId.toString());
+        return createError(string `Failed to complete message with ID ${message?.messageId.toString()}`);
     }
 
     # Abandon message from queue or subscription based on messageLockToken. Abandon processing of the message for 
@@ -133,7 +133,7 @@ public isolated client class MessageReceiver {
         if message?.lockToken.toString() != DEFAULT_MESSAGE_LOCK_TOKEN {
             return abandon(self, message);
         }
-        return createError("Failed to abandon message with ID " + message?.messageId.toString());
+        return createError(string `Failed to abandon message with ID ${message?.messageId.toString()}`);
     }
 
     # Dead-Letter the message & moves the message to the Dead-Letter Queue based on messageLockToken. Transfer 
@@ -151,7 +151,7 @@ public isolated client class MessageReceiver {
         if message?.lockToken.toString() != DEFAULT_MESSAGE_LOCK_TOKEN {
             return deadLetter(self, message, deadLetterReason, deadLetterErrorDescription);
         }
-        return createError("Failed to deadletter message with ID " + message?.messageId.toString());
+        return createError(string `Failed to deadletter message with ID ${message?.messageId.toString()}`);
     }
 
     # Defer the message in a Queue or Subscription based on messageLockToken.  It prevents the message from being 
@@ -189,7 +189,7 @@ public isolated client class MessageReceiver {
         if message?.lockToken.toString() != DEFAULT_MESSAGE_LOCK_TOKEN {
             return renewLock(self, message);
         }
-        return createError("Failed to renew lock on message with ID " + message?.messageId.toString());
+        return createError(string `Failed to renew lock on message with ID ${message?.messageId.toString()}`);
     }
 
     # Closes the ASB sender connection.

--- a/ballerina/receiver.bal
+++ b/ballerina/receiver.bal
@@ -117,7 +117,7 @@ public isolated client class MessageReceiver {
     isolated remote function complete(@display {label: "Message"} Message message)
                                         returns Error? {
         if message?.lockToken.toString() != DEFAULT_MESSAGE_LOCK_TOKEN {
-            return complete(self, message?.lockToken.toString());
+            return complete(self, message);
         }
         return createError("Failed to complete message with ID " + message?.messageId.toString());
     }
@@ -131,7 +131,7 @@ public isolated client class MessageReceiver {
     @display {label: "Abandon Message"}
     isolated remote function abandon(@display {label: "Message"} Message message) returns Error? {
         if message?.lockToken.toString() != DEFAULT_MESSAGE_LOCK_TOKEN {
-            return abandon(self, message?.lockToken.toString());
+            return abandon(self, message);
         }
         return createError("Failed to abandon message with ID " + message?.messageId.toString());
     }
@@ -149,8 +149,7 @@ public isolated client class MessageReceiver {
             @display {label: "Dead Letter Description"}
                                         string? deadLetterErrorDescription = ()) returns Error? {
         if message?.lockToken.toString() != DEFAULT_MESSAGE_LOCK_TOKEN {
-            return deadLetter(self, message?.lockToken.toString(), deadLetterReason,
-                deadLetterErrorDescription);
+            return deadLetter(self, message, deadLetterReason, deadLetterErrorDescription);
         }
         return createError("Failed to deadletter message with ID " + message?.messageId.toString());
     }
@@ -163,7 +162,7 @@ public isolated client class MessageReceiver {
     @display {label: "Defer Message"}
     isolated remote function defer(@display {label: "Message"} Message message)
                                     returns @display {label: "Deferred Msg Seq Num"} int|Error {
-        check defer(self, message?.lockToken.toString());
+        check defer(self, message);
         return <int>message?.sequenceNumber;
     }
 
@@ -188,7 +187,7 @@ public isolated client class MessageReceiver {
     @display {label: "Renew Lock On Message"}
     isolated remote function renewLock(@display {label: "Message"} Message message) returns Error? {
         if message?.lockToken.toString() != DEFAULT_MESSAGE_LOCK_TOKEN {
-            return renewLock(self, message?.lockToken.toString());
+            return renewLock(self, message);
         }
         return createError("Failed to renew lock on message with ID " + message?.messageId.toString());
     }
@@ -213,20 +212,20 @@ isolated function receiveBatch(MessageReceiver endpointClient, int? maxMessageCo
     'class: "org.ballerinax.asb.receiver.MessageReceiver"
 } external;
 
-isolated function complete(MessageReceiver endpointClient, string lockToken) returns Error? = @java:Method {
+isolated function complete(MessageReceiver endpointClient, Message message) returns Error? = @java:Method {
     'class: "org.ballerinax.asb.receiver.MessageReceiver"
 } external;
 
-isolated function abandon(MessageReceiver endpointClient, string lockToken) returns Error? = @java:Method {
+isolated function abandon(MessageReceiver endpointClient, Message message) returns Error? = @java:Method {
     'class: "org.ballerinax.asb.receiver.MessageReceiver"
 } external;
 
-isolated function deadLetter(MessageReceiver endpointClient, string lockToken, string? deadLetterReason, string? deadLetterErrorDescription) returns
+isolated function deadLetter(MessageReceiver endpointClient, Message message, string? deadLetterReason, string? deadLetterErrorDescription) returns
                         Error? = @java:Method {
     'class: "org.ballerinax.asb.receiver.MessageReceiver"
 } external;
 
-isolated function defer(MessageReceiver endpointClient, string lockToken) returns Error? = @java:Method {
+isolated function defer(MessageReceiver endpointClient, Message message) returns Error? = @java:Method {
     'class: "org.ballerinax.asb.receiver.MessageReceiver"
 } external;
 
@@ -234,6 +233,6 @@ isolated function receiveDeferred(MessageReceiver endpointClient, int sequenceNu
     'class: "org.ballerinax.asb.receiver.MessageReceiver"
 } external;
 
-isolated function renewLock(MessageReceiver endpointClient, string lockToken) returns Error? = @java:Method {
+isolated function renewLock(MessageReceiver endpointClient, Message message) returns Error? = @java:Method {
     'class: "org.ballerinax.asb.receiver.MessageReceiver"
 } external;

--- a/ballerina/receiver.bal
+++ b/ballerina/receiver.bal
@@ -119,7 +119,7 @@ public isolated client class MessageReceiver {
         if message?.lockToken.toString() != DEFAULT_MESSAGE_LOCK_TOKEN {
             return complete(self, message);
         }
-        return createError(string `Failed to complete message with ID ${message?.messageId.toString()}`);
+        return createError(string `Failed to complete message with ID: ${message?.messageId.toString()}`);
     }
 
     # Abandon message from queue or subscription based on messageLockToken. Abandon processing of the message for 
@@ -133,7 +133,7 @@ public isolated client class MessageReceiver {
         if message?.lockToken.toString() != DEFAULT_MESSAGE_LOCK_TOKEN {
             return abandon(self, message);
         }
-        return createError(string `Failed to abandon message with ID ${message?.messageId.toString()}`);
+        return createError(string `Failed to abandon message with ID: ${message?.messageId.toString()}`);
     }
 
     # Dead-Letter the message & moves the message to the Dead-Letter Queue based on messageLockToken. Transfer 
@@ -151,7 +151,7 @@ public isolated client class MessageReceiver {
         if message?.lockToken.toString() != DEFAULT_MESSAGE_LOCK_TOKEN {
             return deadLetter(self, message, deadLetterReason, deadLetterErrorDescription);
         }
-        return createError(string `Failed to deadletter message with ID ${message?.messageId.toString()}`);
+        return createError(string `Failed to deadletter message with ID: ${message?.messageId.toString()}`);
     }
 
     # Defer the message in a Queue or Subscription based on messageLockToken.  It prevents the message from being 
@@ -189,7 +189,7 @@ public isolated client class MessageReceiver {
         if message?.lockToken.toString() != DEFAULT_MESSAGE_LOCK_TOKEN {
             return renewLock(self, message);
         }
-        return createError(string `Failed to renew lock on message with ID ${message?.messageId.toString()}`);
+        return createError(string `Failed to renew lock on message with ID: ${message?.messageId.toString()}`);
     }
 
     # Closes the ASB sender connection.

--- a/ballerina/tests/asb_sender_receiver_negative_tests.bal
+++ b/ballerina/tests/asb_sender_receiver_negative_tests.bal
@@ -16,6 +16,9 @@
 
 import ballerina/log;
 import ballerina/test;
+import ballerina/regex;
+
+string invalidCompleteError = "^Failed to complete message with ID:.*$";
 
 @test:Config {
     groups: ["asb_sender_receiver_negative"],
@@ -51,6 +54,46 @@ function testReceivePayloadWithIncorrectExpectedType() returns error? {
 @test:Config {
     groups: ["asb_sender_receiver_negative"],
     dependsOn: [testReceivePayloadWithIncorrectExpectedType]
+}
+function testInvalidComplete() returns error? {
+    log:printInfo("[[testInvalidComplete]");
+
+    log:printInfo("Initializing Asb sender client.");
+    MessageSender messageSender = check new (senderConfig);
+
+    log:printInfo("Initializing Asb receiver client.");
+    receiverConfig.receiveMode = RECEIVE_AND_DELETE;
+
+    MessageReceiver messageReceiver = check new (receiverConfig);
+
+    log:printInfo("Sending via Asb sender.");
+    check messageSender->send(message1);
+
+    log:printInfo("Receiving from Asb receiver client.");
+    Message|error? receivedMessage = messageReceiver->receive(serverWaitTime);
+
+    if receivedMessage is Message {
+        log:printInfo("messgae" + receivedMessage.toString());
+        Error? result = messageReceiver->complete(receivedMessage);
+        test:assertTrue(result is error, msg = "Unexpected Complete for Messages in Receive and Delete Mode");
+        test:assertTrue(regex:matches((<Error>result).message(),invalidCompleteError), msg = "Invalid Complete for " +
+        " Messages in Receive and Delete Mode");
+    } else if receivedMessage is () {
+        test:assertFail("No message in the queue.");
+    } else {
+        test:assertFail("Receiving message via Asb receiver connection failed.");
+    }
+
+    log:printInfo("Closing Asb sender client.");
+    check messageSender->close();
+
+    log:printInfo("Closing Asb receiver client.");
+    check messageSender->close();
+}
+
+@test:Config {
+    groups: ["asb_sender_receiver_negative"],
+    dependsOn: [testInvalidComplete]
 }
 function testReceivePayloadWithUnsupportedUnionExpectedType() returns error? {
     log:printInfo("[[testReceivePayloadWithUnsupportedUnionExpectedType]]");

--- a/ballerina/tests/asb_sender_receiver_negative_tests.bal
+++ b/ballerina/tests/asb_sender_receiver_negative_tests.bal
@@ -19,7 +19,7 @@ import ballerina/test;
 import ballerina/regex;
 
 string invalidCompleteError = "^Failed to complete message with ID:.*$";
-
+string invalidAbandonError = "^Failed to abandon message with ID:.*$";
 @test:Config {
     groups: ["asb_sender_receiver_negative"],
     dependsOn: [testCreateQueue, testCreateTopicOperation, testCreateSubscription]
@@ -88,12 +88,52 @@ function testInvalidComplete() returns error? {
     check messageSender->close();
 
     log:printInfo("Closing Asb receiver client.");
-    check messageSender->close();
+    check messageReceiver->close();
 }
 
 @test:Config {
     groups: ["asb_sender_receiver_negative"],
     dependsOn: [testInvalidComplete]
+}
+function testInvalidAbandon() returns error? {
+    log:printInfo("[[testInvalidAbandon]");
+
+    log:printInfo("Initializing Asb sender client.");
+    MessageSender messageSender = check new (senderConfig);
+
+    log:printInfo("Initializing Asb receiver client.");
+    receiverConfig.receiveMode = RECEIVE_AND_DELETE;
+
+    MessageReceiver messageReceiver = check new (receiverConfig);
+
+    log:printInfo("Sending via Asb sender.");
+    check messageSender->send(message1);
+
+    log:printInfo("Receiving from Asb receiver client.");
+    Message|error? receivedMessage = messageReceiver->receive(serverWaitTime);
+
+    if receivedMessage is Message {
+        log:printInfo("messgae" + receivedMessage.toString());
+        Error? result = messageReceiver->abandon(receivedMessage);
+        test:assertTrue(result is error, msg = "Unexpected Abandon for Messages in Receive and Delete Mode");
+        test:assertTrue(regex:matches((<Error>result).message(),invalidAbandonError), msg = "Invalid Abandon for " +
+        " Messages in Receive and Delete Mode");
+    } else if receivedMessage is () {
+        test:assertFail("No message in the queue.");
+    } else {
+        test:assertFail("Receiving message via Asb receiver connection failed.");
+    }
+
+    log:printInfo("Closing Asb sender client.");
+    check messageSender->close();
+
+    log:printInfo("Closing Asb receiver client.");
+    check messageReceiver->close();
+}
+
+@test:Config {
+    groups: ["asb_sender_receiver_negative"],
+    dependsOn: [testInvalidAbandon]
 }
 function testReceivePayloadWithUnsupportedUnionExpectedType() returns error? {
     log:printInfo("[[testReceivePayloadWithUnsupportedUnionExpectedType]]");

--- a/native/src/main/java/org/ballerinax/asb/receiver/MessageReceiver.java
+++ b/native/src/main/java/org/ballerinax/asb/receiver/MessageReceiver.java
@@ -302,7 +302,6 @@ public class MessageReceiver {
         try {
             ServiceBusReceiverClient receiver = getReceiverFromBObject(receiverClient);
             ServiceBusReceivedMessage nativeMessage = getNativeMessage(message);
-            ;
             receiver.abandon(nativeMessage);
             LOGGER.debug(String.format("Done abandoning a message(Id: %s) using its lock token from %n%s",
                     nativeMessage.getMessageId(), receiver.getEntityPath()));

--- a/native/src/main/java/org/ballerinax/asb/util/ASBConstants.java
+++ b/native/src/main/java/org/ballerinax/asb/util/ASBConstants.java
@@ -26,13 +26,14 @@ import io.ballerina.runtime.api.values.BString;
  */
 public class ASBConstants {
 
-    //Clients
+    //Native Object Identifiers
     public static final String RECEIVER_CLIENT = "RECEIVER_CLIENT";
     public static final String ADMINISTRATOR_CLIENT = "ADMINISTRATOR_CLIENT";
     public static final String SENDER_CLIENT = "SENDER_CLIENT";
     public static final String DEAD_LETTER_RECEIVER_CLIENT = "DEAD_LETTER_RECEIVER_CLIENT";
+    public static final String NATIVE_MESSAGE = "NATIVE_MESSAGE";
 
-    //Client Init Data
+    //Receiver Client Init Data
     public static final String RECEIVER_CLIENT_CONNECTION_STRING = "CONNECTION_STRING";
     public static final String RECEIVER_CLIENT_RECEIVE_MODE = "RECEIVE_MODE";
     public static final String RECEIVER_CLIENT_TOPIC_NAME = "TOPIC_NAME";
@@ -45,17 +46,20 @@ public class ASBConstants {
     // Message constant fields
     public static final String MESSAGE_RECORD = "Message";
     public static final String APPLICATION_PROPERTY_TYPE = "ApplicationProperties";
+
     // Message content data binding errors
     public static final String XML_CONTENT_ERROR = "Error while retrieving the xml content of the message. ";
     public static final String JSON_CONTENT_ERROR = "Error while retrieving the json content of the message. ";
     public static final String TEXT_CONTENT_ERROR = "Error while retrieving the string content of the message. ";
     public static final String INT_CONTENT_ERROR = "Error while retrieving the int content of the message. ";
     public static final String FLOAT_CONTENT_ERROR = "Error while retrieving the float content of the message. ";
+
     // Batch Message constant fields
     public static final String MESSAGE_BATCH_RECORD = "MessageBatch";
     public static final String MESSAGES_OBJECT = "Messages";
     public static final BString MESSAGES_CONTENT = StringUtils.fromString("messages");
     public static final BString MESSAGE_COUNT = StringUtils.fromString("messageCount");
+
     // Message receive modes
     public static final String PEEK_LOCK = "PEEKLOCK";
     public static final String RECEIVE_AND_DELETE = "RECEIVEANDDELETE";
@@ -115,6 +119,7 @@ public class ASBConstants {
     // Error constant fields
     static final String ASB_ERROR = "Error";
 
+    // Subscription/Topic/Queue Properties record fields
     public static final String SUBSCRIPTION_CREATED_RECORD = "SubscriptionProperties";
     public static final String TOPIC_CREATED_RECORD = "TopicProperties";
     public static final String QUEUE_CREATED_RECORD = "QueueProperties";
@@ -326,6 +331,7 @@ public class ASBConstants {
             "deadLetteringOnFilterEvaluationExceptions";
     public static final String CREATED_SUBSCRIPTION_RECORD_FIELD_SESSION_REQUIRED =
             "requiresSession";
+
     // Subscription List
     public static final String LIST_OF_SUBSCRIPTIONS = "list";
     public static final String LIST_OF_SUBSCRIPTIONS_RECORD = "SubscriptionList";
@@ -342,6 +348,7 @@ public class ASBConstants {
     public static final String CREATED_RULE_RECORD_FIELD_TYPE_NAME = "rule";
     public static final String CREATED_RULE_RECORD_FIELD_ACTION = "action";
     public static final String CREATED_RULE_RECORD_FIELD_FILTER = "filter";
+
     // Rule List
     public static final String LIST_OF_RULES = "list";
     public static final String LIST_OF_RULES_RECORD = "RuleList";


### PR DESCRIPTION
# Description

The issue has been resolved by placing the Java-side message object as the native data within the message itself, rather than associating it with a receiver client. This way, the garbage collector will take care of cases involving data that is not handled(data that didn't go through a completion, abandonment, or movement to the dead letter queue).

Fixes [Data Retention Issue](https://github.com/ballerina-platform/ballerina-extended-library/issues/562)

Related Pull Requests (remove if not relevant)
- https://github.com/ballerina-platform/module-ballerinax-azure-service-bus/pull/193 (Previous Method of Solving the Issue)

One line release note: 
- Fix Native Data Retention Issue

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

![JProfiler Screen Record](https://github.com/RDPerera/img-repo/blob/main/jprofile-anlysis.gif?raw=true)

The new solution was tested by sending large messages over an extended period of time without handling them through the testing application. Subsequently, an analysis of memory usage and garbage collection behavior was conducted using JProfiler. As indicated in above figure, it was observed that the garbage collector successfully cleaned up the unhandled messages after period of time.