### PR TITLE
Exclude `netty-buffer` and `jackson-annotations` from the native-jar

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -22,14 +22,14 @@ module = "asb-native"
 version = "3.8.1-SNAPSHOT"
 path = "../native/build/libs/asb-native-3.8.1-SNAPSHOT.jar"
 
-[[platform.java11.dependency]]
+[[platform.java17.dependency]]
 groupId = "com.fasterxml.jackson.core"
-artifactId = "jackson-databind"
+artifactId = "jackson-annotations"
 version = "2.17.0"
-path = "./lib/jackson-databind-2.17.0.jar"
+path = "./lib/jackson-annotations-2.17.0.jar"
 
-[[platform.java11.dependency]]
-groupId = "com.fasterxml.jackson.core"
-artifactId = "jackson-databind"
-version = "2.17.0"
-path = "./lib/jackson-databind-2.17.0.jar"
+[[platform.java17.dependency]]
+groupId = "io.netty"
+artifactId = "netty-buffer"
+version = "4.1.94.Final"
+path = "./lib/netty-buffer-4.1.94.Final.jar"

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -21,3 +21,15 @@ artifactId = "asb-native"
 module = "asb-native" 
 version = "3.8.1-SNAPSHOT"
 path = "../native/build/libs/asb-native-3.8.1-SNAPSHOT.jar"
+
+[[platform.java11.dependency]]
+groupId = "com.fasterxml.jackson.core"
+artifactId = "jackson-databind"
+version = "2.17.0"
+path = "./lib/jackson-databind-2.17.0.jar"
+
+[[platform.java11.dependency]]
+groupId = "com.fasterxml.jackson.core"
+artifactId = "jackson-databind"
+version = "2.17.0"
+path = "./lib/jackson-databind-2.17.0.jar"

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -25,8 +25,8 @@ path = "../native/build/libs/asb-native-3.8.1-SNAPSHOT.jar"
 [[platform.java17.dependency]]
 groupId = "com.fasterxml.jackson.core"
 artifactId = "jackson-annotations"
-version = "2.17.0"
-path = "./lib/jackson-annotations-2.17.0.jar"
+version = "2.13.5"
+path = "./lib/jackson-annotations-2.13.5.jar"
 
 [[platform.java17.dependency]]
 groupId = "io.netty"

--- a/ballerina/build.gradle
+++ b/ballerina/build.gradle
@@ -56,10 +56,21 @@ configurations {
     externalJars
 }
 
+dependencies {
+    externalJars(group: 'com.fasterxml.jackson.core', name: 'jackson-annotations', version: "${jacksonVersion}") {
+        transitive = false
+    }
+    externalJars(group: 'io.netty', name: 'netty-buffer', version: "${nettyVersion}") {
+        transitive = false
+    }
+}
+
 task updateTomlFiles {
     doLast {
         def newBallerinaToml = ballerinaTomlFilePlaceHolder.text.replace("@project.version@", project.version)
         newBallerinaToml = newBallerinaToml.replace("@toml.version@", tomlVersion)
+        newBallerinaToml = newBallerinaToml.replace("@jackson.version@", project.jacksonVersion)
+        newBallerinaToml = newBallerinaToml.replace("@netty.version@", project.nettyVersion)
         ballerinaTomlFile.text = newBallerinaToml
     }
 }

--- a/build-config/resources/Ballerina.toml
+++ b/build-config/resources/Ballerina.toml
@@ -21,3 +21,15 @@ artifactId = "asb-native"
 module = "asb-native" 
 version = "@project.version@"
 path = "../native/build/libs/asb-native-@project.version@.jar"
+
+[[platform.java17.dependency]]
+groupId = "com.fasterxml.jackson.core"
+artifactId = "jackson-annotations"
+version = "@jackson.version@"
+path = "./lib/jackson-annotations-@jackson.version@.jar"
+
+[[platform.java17.dependency]]
+groupId = "io.netty"
+artifactId = "netty-buffer"
+version = "@netty.version@"
+path = "./lib/netty-buffer-@netty.version@.jar"

--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- [Application written with `ballerina/asb` connector gives a conflicting JAR warning with `netty-buffer` and `jackson-annotations`](https://github.com/ballerina-platform/ballerina-library/issues/7061)
+
 ## [3.8.1] - 2024-09-30
 
 ### Fixed

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,3 +12,5 @@ ballerinaGradlePluginVersion=2.2.4
 ballerinaLangVersion=2201.8.0
 azureServiceBusVersion=7.14.3
 slf4jVersion=1.7.30
+nettyVersion=4.1.94.Final
+jacksonVersion=2.13.5

--- a/native/build.gradle
+++ b/native/build.gradle
@@ -43,8 +43,6 @@ dependencies {
     dist (group: 'com.azure', name: 'azure-messaging-servicebus', version: "${azureServiceBusVersion}") {
         exclude group: "com.fasterxml.woodstox", module: "woodstox-core"
         exclude group: "org.codehaus.woodstox", module: "stax2-api"
-        exclude group: "com.fasterxml.jackson.core", module: "jackson-annotations"
-        exclude group: "io.netty", module: "netty-buffer"
     }
 }
 

--- a/native/build.gradle
+++ b/native/build.gradle
@@ -43,6 +43,8 @@ dependencies {
     dist (group: 'com.azure', name: 'azure-messaging-servicebus', version: "${azureServiceBusVersion}") {
         exclude group: "com.fasterxml.woodstox", module: "woodstox-core"
         exclude group: "org.codehaus.woodstox", module: "stax2-api"
+        exclude group: "com.fasterxml.jackson.core", module: "jackson-annotations"
+        exclude group: "io.netty", module: "netty-buffer"
     }
 }
 


### PR DESCRIPTION
## Purpose
> $subject

Fixes: https://github.com/ballerina-platform/ballerina-library/issues/7061

## Examples
N/A

## Checklist
- [X] Linked to an issue
- [ ] ~Updated the specification~
- [x] Updated the changelog
- [ ] ~Added tests~
- [ ] ~Checked native-image compatibility~