### PR TITLE
Revert "Upgrade azure-messaging-servicebus SDK to 7.17.17"

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ releasePluginVersion=2.8.0
 ballerinaGradlePluginVersion=2.3.0
 
 ballerinaLangVersion=2201.11.0
-azureServiceBusVersion=7.17.17
+azureServiceBusVersion=7.14.3
 slf4jVersion=1.7.30
 nettyVersion=4.1.118.Final
 boringSslVersion=2.0.70.Final


### PR DESCRIPTION
## Purpose
Revert "Upgrade azure-messaging-servicebus SDK to 7.17.17"


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This pull request reverts the Azure Service Bus SDK dependency to a previous stable version by downgrading from 7.17.17 to 7.14.3 in the `gradle.properties` file. The change affects the `azureServiceBusVersion` property used throughout the project's Azure Service Bus integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->