### PR TITLE
Revert "Upgrade jackson-annotations to 2.21"

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -25,8 +25,8 @@ path = "../native/build/libs/asb-native-3.9.2-SNAPSHOT.jar"
 [[platform.java21.dependency]]
 groupId = "com.fasterxml.jackson.core"
 artifactId = "jackson-annotations"
-version = "2.21"
-path = "./lib/jackson-annotations-2.21.jar"
+version = "2.13.5"
+path = "./lib/jackson-annotations-2.13.5.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.netty"

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,4 +14,4 @@ azureServiceBusVersion=7.17.17
 slf4jVersion=1.7.30
 nettyVersion=4.1.118.Final
 boringSslVersion=2.0.70.Final
-jacksonVersion=2.21
+jacksonVersion=2.13.5


### PR DESCRIPTION
Reverts ballerina-platform/module-ballerinax-asb#256

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This pull request reverts the jackson-annotations dependency version from 2.21 back to 2.13.5 across the project's build configuration files.

## Changes

- **ballerina/Ballerina.toml**: Updated the `platform.java21` dependency for `com.fasterxml.jackson.core:jackson-annotations`
  - Version: `2.21` → `2.13.5`
  - Local jar path: `./lib/jackson-annotations-2.21.jar` → `./lib/jackson-annotations-2.13.5.jar`

- **gradle.properties**: Downgraded `jacksonVersion` property from `2.21` to `2.13.5`

This change reverts the upgrade that was introduced in PR #256.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->