### PR TITLE
Fix extracting rule properties in updateRule

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,9 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-
-- [Application written with `ballerina/asb` connector gives a conflicting JAR warning with `netty-buffer` and `jackson-annotations`](https://github.com/ballerina-platform/ballerina-library/issues/7061)
 - [Fix `updateRule` not applying filter and action changes due to incorrect field extraction from nested `SqlRule` record](https://github.com/ballerina-platform/ballerina-library/issues/8730)
+
+## [3.8.2] - 2024-10-01
+
+### Fixed
+- [Application written with `ballerina/asb` connector gives a conflicting JAR warning with `netty-buffer` and `jackson-annotations`](https://github.com/ballerina-platform/ballerina-library/issues/7061)
 
 ## [3.8.1] - 2024-09-30
 

--- a/changelog.md
+++ b/changelog.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - [Application written with `ballerina/asb` connector gives a conflicting JAR warning with `netty-buffer` and `jackson-annotations`](https://github.com/ballerina-platform/ballerina-library/issues/7061)
-- Fix `updateRule` not applying filter and action changes due to incorrect field extraction from nested `SqlRule` record
+- [Fix `updateRule` not applying filter and action changes due to incorrect field extraction from nested `SqlRule` record](https://github.com/ballerina-platform/ballerina-library/issues/8730)
 
 ## [3.8.1] - 2024-09-30
 

--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - [Application written with `ballerina/asb` connector gives a conflicting JAR warning with `netty-buffer` and `jackson-annotations`](https://github.com/ballerina-platform/ballerina-library/issues/7061)
+- Fix `updateRule` not applying filter and action changes due to incorrect field extraction from nested `SqlRule` record
 
 ## [3.8.1] - 2024-09-30
 

--- a/native/src/main/java/io/ballerina/lib/asb/util/ASBUtils.java
+++ b/native/src/main/java/io/ballerina/lib/asb/util/ASBUtils.java
@@ -500,13 +500,19 @@ public class ASBUtils {
      */
     public static RuleProperties getUpdatedRulePropertiesFromBObject(BMap<BString, Object> ruleConfig,
                                                                      RuleProperties ruleProp) {
-        if (ruleConfig.containsKey(ASBConstants.RECORD_FIELD_ACTION)) {
-            ruleProp.setAction(new SqlRuleAction(
-                    ruleConfig.getStringValue(ASBConstants.RECORD_FIELD_ACTION).getValue()));
-        }
-        if (ruleConfig.containsKey(ASBConstants.RECORD_FIELD_FILTER)) {
-            ruleProp.setFilter(new SqlRuleFilter(
-                    ruleConfig.getStringValue(ASBConstants.RECORD_FIELD_FILTER).getValue()));
+        if (ruleConfig.containsKey(ASBConstants.RECORD_FIELD_SQL_RULE)) {
+            if (ruleConfig.getMapValue(ASBConstants.RECORD_FIELD_SQL_RULE).containsKey(
+                    ASBConstants.RECORD_FIELD_ACTION)) {
+                ruleProp.setAction(new SqlRuleAction(
+                        ruleConfig.getMapValue(ASBConstants.RECORD_FIELD_SQL_RULE).getStringValue(
+                                ASBConstants.RECORD_FIELD_ACTION).getValue()));
+            }
+            if (ruleConfig.getMapValue(ASBConstants.RECORD_FIELD_SQL_RULE).containsKey(
+                    ASBConstants.RECORD_FIELD_FILTER)) {
+                ruleProp.setFilter(new SqlRuleFilter(
+                        ruleConfig.getMapValue(ASBConstants.RECORD_FIELD_SQL_RULE).getStringValue(
+                                ASBConstants.RECORD_FIELD_FILTER).getValue()));
+            }
         }
         return ruleProp;
     }


### PR DESCRIPTION
## Purpose
Resolves : https://github.com/ballerina-platform/ballerina-library/issues/8730
Fix the `updateRule` operation in the Admin client which was not actually updating rule properties (filter/action).

The `getUpdatedRulePropertiesFromBObject`method in `ASBUtils.java`was incorrectly looking for `action` and `filter` fields at the top level of the `UpdateRuleOptions` BMap. However, the Ballerina `UpdateRuleOptions` record nests these fields inside a `SqlRule rule` field. This meant the update was silently ignored and the existing rule properties were returned unchanged.

The fix aligns the update logic with the create logic `getCreateRulePropertiesFromBObject`, correctly reading from the nested `rule` (`RECORD_FIELD_SQL_RULE`) map.

## Examples

```ballerina
// Before fix: this would silently do nothing
asb:SqlRule sqlRule = {filter: "1=1", action: "SET x = 5"};
asb:RuleProperties? rule = check adminClient->updateRule("topic", "subscription", "rule", rule = sqlRule);

// After fix: rule filter and action are correctly updated

```
## Checklist
- [x] Linked to an issue
- [ ] Updated the specification
- [x] Updated the changelog
- [ ] Added tests
- [x] Checked native-image compatibility