### PR TITLE
Fix updateRule not applying filter/action due to incorrect field extraction from nested SqlRule record

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,11 @@ This file contains all the notable changes done to the Ballerina WebSub package 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- [Fix `updateRule` not applying filter and action changes due to incorrect field extraction from nested `SqlRule` record](https://github.com/ballerina-platform/ballerina-library/issues/8730)
+
 ## [3.9.1] - 2024-08-07
 
 #### Fixed

--- a/native/src/main/java/io/ballerina/lib/asb/util/ASBUtils.java
+++ b/native/src/main/java/io/ballerina/lib/asb/util/ASBUtils.java
@@ -500,13 +500,18 @@ public class ASBUtils {
      */
     public static RuleProperties getUpdatedRulePropertiesFromBObject(BMap<BString, Object> ruleConfig,
                                                                      RuleProperties ruleProp) {
-        if (ruleConfig.containsKey(ASBConstants.RECORD_FIELD_ACTION)) {
-            ruleProp.setAction(new SqlRuleAction(
-                    ruleConfig.getStringValue(ASBConstants.RECORD_FIELD_ACTION).getValue()));
-        }
-        if (ruleConfig.containsKey(ASBConstants.RECORD_FIELD_FILTER)) {
-            ruleProp.setFilter(new SqlRuleFilter(
-                    ruleConfig.getStringValue(ASBConstants.RECORD_FIELD_FILTER).getValue()));
+        @SuppressWarnings("unchecked")
+        BMap<BString, Object> sqlRule = (BMap<BString, Object>) ruleConfig.getMapValue(
+                ASBConstants.RECORD_FIELD_SQL_RULE);
+        if (sqlRule != null) {
+            if (sqlRule.containsKey(ASBConstants.RECORD_FIELD_ACTION)) {
+                ruleProp.setAction(new SqlRuleAction(
+                        sqlRule.getStringValue(ASBConstants.RECORD_FIELD_ACTION).getValue()));
+            }
+            if (sqlRule.containsKey(ASBConstants.RECORD_FIELD_FILTER)) {
+                ruleProp.setFilter(new SqlRuleFilter(
+                        sqlRule.getStringValue(ASBConstants.RECORD_FIELD_FILTER).getValue()));
+            }
         }
         return ruleProp;
     }


### PR DESCRIPTION
## Purpose
$Subject

## Examples

## Checklist
- [ ] Linked to an issue
- [ ] Updated the specification
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Checked native-image compatibility

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This pull request fixes an issue where the `updateRule` operation was not correctly applying filter and action changes when updating Azure Service Bus rules. The root cause was that field extraction logic was attempting to read these properties from the wrong location in the rule configuration object.

## Changes Made

**ASBUtils.java** - Updated the `getUpdatedRulePropertiesFromBObject` method to correctly extract filter and action properties from the nested `sql_rule` map structure, rather than attempting to retrieve them from the top level of the rule configuration.

**changelog.md** - Added documentation of this fix in the changelog.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ballerina-platform/module-ballerinax-asb/pull/269)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->