### PR TITLE
Update package dependencies

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -26,38 +26,32 @@ path = "../native/build/libs/asb-native-3.9.2-SNAPSHOT.jar"
 [[platform.java21.dependency]]
 groupId = "com.azure"
 artifactId = "azure-messaging-servicebus"
-version = "7.17.17"
-path = "./lib/azure-messaging-servicebus-7.17.17.jar"
+version = "7.14.3"
+path = "./lib/azure-messaging-servicebus-7.14.3.jar"
 
 [[platform.java21.dependency]]
 groupId = "com.azure"
 artifactId = "azure-core"
-version = "1.57.1"
-path = "./lib/azure-core-1.57.1.jar"
+version = "1.42.0"
+path = "./lib/azure-core-1.42.0.jar"
 
 [[platform.java21.dependency]]
 groupId = "com.azure"
 artifactId = "azure-core-amqp"
-version = "2.11.3"
-path = "./lib/azure-core-amqp-2.11.3.jar"
+version = "2.8.8"
+path = "./lib/azure-core-amqp-2.8.8.jar"
 
 [[platform.java21.dependency]]
 groupId = "com.azure"
 artifactId = "azure-core-http-netty"
-version = "1.16.3"
-path = "./lib/azure-core-http-netty-1.16.3.jar"
+version = "1.13.6"
+path = "./lib/azure-core-http-netty-1.13.6.jar"
 
 [[platform.java21.dependency]]
 groupId = "com.azure"
 artifactId = "azure-json"
-version = "1.4.0"
-path = "./lib/azure-json-1.4.0.jar"
-
-[[platform.java21.dependency]]
-groupId = "com.azure"
-artifactId = "azure-xml"
-version = "1.2.1"
-path = "./lib/azure-xml-1.2.1.jar"
+version = "1.0.1"
+path = "./lib/azure-json-1.0.1.jar"
 
 [[platform.java21.dependency]]
 groupId = "com.microsoft.azure"
@@ -69,141 +63,141 @@ path = "./lib/qpid-proton-j-extensions-1.2.4.jar"
 [[platform.java21.dependency]]
 groupId = "com.fasterxml.jackson.core"
 artifactId = "jackson-annotations"
-version = "2.21"
-path = "./lib/jackson-annotations-2.21.jar"
+version = "2.18.6"
+path = "./lib/jackson-annotations-2.18.6.jar"
 
 [[platform.java21.dependency]]
 groupId = "com.fasterxml.jackson.core"
 artifactId = "jackson-core"
-version = "2.21.1"
-path = "./lib/jackson-core-2.21.1.jar"
+version = "2.18.6"
+path = "./lib/jackson-core-2.18.6.jar"
 
 [[platform.java21.dependency]]
 groupId = "com.fasterxml.jackson.core"
 artifactId = "jackson-databind"
-version = "2.21.1"
-path = "./lib/jackson-databind-2.21.1.jar"
+version = "2.18.6"
+path = "./lib/jackson-databind-2.18.6.jar"
 
 [[platform.java21.dependency]]
 groupId = "com.fasterxml.jackson.datatype"
 artifactId = "jackson-datatype-jsr310"
-version = "2.21.1"
-path = "./lib/jackson-datatype-jsr310-2.21.1.jar"
+version = "2.18.6"
+path = "./lib/jackson-datatype-jsr310-2.18.6.jar"
 
 [[platform.java21.dependency]]
 groupId = "com.fasterxml.jackson.dataformat"
 artifactId = "jackson-dataformat-xml"
-version = "2.21.1"
-path = "./lib/jackson-dataformat-xml-2.21.1.jar"
+version = "2.18.6"
+path = "./lib/jackson-dataformat-xml-2.18.6.jar"
 
 # Netty dependencies
 [[platform.java21.dependency]]
 groupId = "io.netty"
 artifactId = "netty-buffer"
-version = "4.1.130.Final"
-path = "./lib/netty-buffer-4.1.130.Final.jar"
+version = "4.1.132.Final"
+path = "./lib/netty-buffer-4.1.132.Final.jar"
 
 
 [[platform.java21.dependency]]
 groupId = "io.netty"
 artifactId = "netty-codec"
-version = "4.1.130.Final"
-path = "./lib/netty-codec-4.1.130.Final.jar"
+version = "4.1.132.Final"
+path = "./lib/netty-codec-4.1.132.Final.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.netty"
 artifactId = "netty-codec-dns"
-version = "4.1.130.Final"
-path = "./lib/netty-codec-dns-4.1.130.Final.jar"
+version = "4.1.132.Final"
+path = "./lib/netty-codec-dns-4.1.132.Final.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.netty"
 artifactId = "netty-codec-http"
-version = "4.1.130.Final"
-path = "./lib/netty-codec-http-4.1.130.Final.jar"
+version = "4.1.132.Final"
+path = "./lib/netty-codec-http-4.1.132.Final.jar"
 
 
 [[platform.java21.dependency]]
 groupId = "io.netty"
 artifactId = "netty-codec-http2"
-version = "4.1.130.Final"
-path = "./lib/netty-codec-http2-4.1.130.Final.jar"
+version = "4.1.132.Final"
+path = "./lib/netty-codec-http2-4.1.132.Final.jar"
 
 
 [[platform.java21.dependency]]
 groupId = "io.netty"
 artifactId = "netty-codec-socks"
-version = "4.1.130.Final"
-path = "./lib/netty-codec-socks-4.1.130.Final.jar"
+version = "4.1.132.Final"
+path = "./lib/netty-codec-socks-4.1.132.Final.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.netty"
 artifactId = "netty-common"
-version = "4.1.130.Final"
-path = "./lib/netty-common-4.1.130.Final.jar"
+version = "4.1.132.Final"
+path = "./lib/netty-common-4.1.132.Final.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.netty"
 artifactId = "netty-handler"
-version = "4.1.130.Final"
-path = "./lib/netty-handler-4.1.130.Final.jar"
+version = "4.1.132.Final"
+path = "./lib/netty-handler-4.1.132.Final.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.netty"
 artifactId = "netty-handler-proxy"
-version = "4.1.130.Final"
-path = "./lib/netty-handler-proxy-4.1.130.Final.jar"
+version = "4.1.132.Final"
+path = "./lib/netty-handler-proxy-4.1.132.Final.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.netty"
 artifactId = "netty-resolver"
-version = "4.1.130.Final"
-path = "./lib/netty-resolver-4.1.130.Final.jar"
+version = "4.1.132.Final"
+path = "./lib/netty-resolver-4.1.132.Final.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.netty"
 artifactId = "netty-resolver-dns"
-version = "4.1.130.Final"
-path = "./lib/netty-resolver-dns-4.1.130.Final.jar"
+version = "4.1.132.Final"
+path = "./lib/netty-resolver-dns-4.1.132.Final.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.netty"
 artifactId = "netty-resolver-dns-classes-macos"
-version = "4.1.130.Final"
-path = "./lib/netty-resolver-dns-classes-macos-4.1.130.Final.jar"
+version = "4.1.132.Final"
+path = "./lib/netty-resolver-dns-classes-macos-4.1.132.Final.jar"
 
 [[platform.java21.dependency]]
-path = "./lib/netty-resolver-dns-native-macos-4.1.130.Final-osx-x86_64.jar"
+path = "./lib/netty-resolver-dns-native-macos-4.1.132.Final-osx-x86_64.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.netty"
 artifactId = "netty-transport"
-version = "4.1.130.Final"
-path = "./lib/netty-transport-4.1.130.Final.jar"
+version = "4.1.132.Final"
+path = "./lib/netty-transport-4.1.132.Final.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.netty"
 artifactId = "netty-transport-classes-epoll"
-version = "4.1.130.Final"
-path = "./lib/netty-transport-classes-epoll-4.1.130.Final.jar"
+version = "4.1.132.Final"
+path = "./lib/netty-transport-classes-epoll-4.1.132.Final.jar"
 
 [[platform.java21.dependency]]
-path = "./lib/netty-transport-native-epoll-4.1.130.Final-linux-x86_64.jar"
+path = "./lib/netty-transport-native-epoll-4.1.132.Final-linux-x86_64.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.netty"
 artifactId = "netty-transport-classes-kqueue"
-version = "4.1.130.Final"
-path = "./lib/netty-transport-classes-kqueue-4.1.130.Final.jar"
+version = "4.1.132.Final"
+path = "./lib/netty-transport-classes-kqueue-4.1.132.Final.jar"
 
 [[platform.java21.dependency]]
-path = "./lib/netty-transport-native-kqueue-4.1.130.Final-osx-x86_64.jar"
+path = "./lib/netty-transport-native-kqueue-4.1.132.Final-osx-x86_64.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.netty"
 artifactId = "netty-transport-native-unix-common"
-version = "4.1.130.Final"
-path = "./lib/netty-transport-native-unix-common-4.1.130.Final.jar"
+version = "4.1.132.Final"
+path = "./lib/netty-transport-native-unix-common-4.1.132.Final.jar"
 
 # Netty tcnative dependencies
 [[platform.java21.dependency]]
@@ -243,14 +237,14 @@ path = "./lib/reactor-core-3.7.7.jar"
 [[platform.java21.dependency]]
 groupId = "io.projectreactor.netty"
 artifactId = "reactor-netty-core"
-version = "1.2.5"
-path = "./lib/reactor-netty-core-1.2.5.jar"
+version = "1.2.8"
+path = "./lib/reactor-netty-core-1.2.8.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.projectreactor.netty"
 artifactId = "reactor-netty-http"
-version = "1.2.5"
-path = "./lib/reactor-netty-http-1.2.5.jar"
+version = "1.2.8"
+path = "./lib/reactor-netty-http-1.2.8.jar"
 
 # Apache proton-j dependencies
 [[platform.java21.dependency]]

--- a/ballerina/build.gradle
+++ b/ballerina/build.gradle
@@ -75,9 +75,6 @@ dependencies {
     externalJars(group: 'com.azure', name: 'azure-json', version: "${azureJsonVersion}") {
         transitive = false
     }
-    externalJars(group: 'com.azure', name: 'azure-xml', version: "${azureXmlVersion}") {
-        transitive = false
-    }
 
     /* Jackson dependencies */
     externalJars(group: 'com.fasterxml.jackson.core', name: 'jackson-annotations', version: "${jacksonAnnotationsVersion}") {
@@ -194,7 +191,6 @@ task updateTomlFiles {
         newBallerinaToml = newBallerinaToml.replace("@azure.core.http.netty.version@", project.azureCoreHttpNettyVersion)
         newBallerinaToml = newBallerinaToml.replace("@azure.qpid.protonj.version@", project.azureQpidProtonJExVersion)
         newBallerinaToml = newBallerinaToml.replace("@azure.json.version@", project.azureJsonVersion)
-        newBallerinaToml = newBallerinaToml.replace("@azure.xml.version@", project.azureXmlVersion)
         newBallerinaToml = newBallerinaToml.replace("@jackson.annotations.version@", project.jacksonAnnotationsVersion)
         newBallerinaToml = newBallerinaToml.replace("@jackson.core.version@", project.jacksonCoreVersion)
         newBallerinaToml = newBallerinaToml.replace("@jackson.databind.version@", project.jacksonDatabindVersion)

--- a/build-config/resources/Ballerina.toml
+++ b/build-config/resources/Ballerina.toml
@@ -54,12 +54,6 @@ version = "@azure.json.version@"
 path = "./lib/azure-json-@azure.json.version@.jar"
 
 [[platform.java21.dependency]]
-groupId = "com.azure"
-artifactId = "azure-xml"
-version = "@azure.xml.version@"
-path = "./lib/azure-xml-@azure.xml.version@.jar"
-
-[[platform.java21.dependency]]
 groupId = "com.microsoft.azure"
 artifactId = "qpid-proton-j-extensions"
 version = "@azure.qpid.protonj.version@"

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,28 +13,27 @@ ballerinaLangVersion=2201.11.0
 slf4jVersion=1.7.30
 
 # Azure dependencies
-asbVersion=7.17.17
-azureCoreVersion=1.57.1
-azureCoreAmqpVersion=2.11.3
-azureCoreHttpNettyVersion=1.16.3
+asbVersion=7.14.3
+azureCoreVersion=1.42.0
+azureCoreAmqpVersion=2.8.8
+azureCoreHttpNettyVersion=1.13.6
 azureQpidProtonJExVersion=1.2.4
-azureJsonVersion=1.4.0
-azureXmlVersion=1.2.1
+azureJsonVersion=1.0.1
 
 # Jackson dependencies
-jacksonAnnotationsVersion=2.21
-jacksonCoreVersion=2.21.1
-jacksonDatabindVersion=2.21.1
-jacksonDatatypeJsrVersion=2.21.1
-jacksonDataFormatXmlVersion=2.21.1
+jacksonAnnotationsVersion=2.18.6
+jacksonCoreVersion=2.18.6
+jacksonDatabindVersion=2.18.6
+jacksonDatatypeJsrVersion=2.18.6
+jacksonDataFormatXmlVersion=2.18.6
 
 # Netty dependencies
-nettyVersion=4.1.130.Final
+nettyVersion=4.1.132.Final
 nettyTcnativeVersion=2.0.74.Final
 
 # Reactor dependencies
 reactorCoreVersion=3.7.7
-reactorNettyVersion=1.2.5
+reactorNettyVersion=1.2.8
 reactiveStreamsVersion=1.0.4
 
 # Apache proton-j dependencies


### PR DESCRIPTION
## Purpose
> $subject

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This pull request updates package dependencies across the Ballerina Azure Service Bus connector module to realign with specific dependency versions.

### Changes Made

**Dependency Version Updates:**
- **Azure Service Bus and Core Libraries**: Downgraded Azure Service Bus from `7.17.17` to `7.14.3` and realigned related Azure libraries (`azure-core`, `azure-core-amqp`, `azure-core-http-netty`, and `azure-json`) to earlier compatible versions
- **Azure XML**: Removed the `azure-xml` dependency entirely from the build configuration
- **Jackson Libraries**: Updated from `2.21.x` series to `2.18.6` across all modules (annotations, core, databind, datatypes, and XML format)
- **Netty**: Updated from `4.1.130.Final` to `4.1.132.Final` for core and native components
- **Reactor Netty**: Updated from `1.2.5` to `1.2.8` for both core and HTTP modules

**Files Modified:**
- `gradle.properties`: Updated version property declarations for multiple dependency groups
- `ballerina/Ballerina.toml`: Updated Java 21 platform dependency entries with new versions and corresponding jar paths
- `ballerina/build.gradle`: Removed Azure XML from external dependencies and related build task configuration
- `build-config/resources/Ballerina.toml`: Removed Azure XML from the platform dependency manifest

### Impact

The changes consolidate and realign the module's dependency footprint to specific versions of core libraries across Azure, Jackson, Netty, and Reactor ecosystems. The removal of the Azure XML dependency simplifies the dependency tree.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ballerina-platform/module-ballerinax-asb/pull/270)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->