### PR TITLE
Bump netty version to `v4.1.133.Final`

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -94,110 +94,110 @@ path = "./lib/jackson-dataformat-xml-2.18.6.jar"
 [[platform.java21.dependency]]
 groupId = "io.netty"
 artifactId = "netty-buffer"
-version = "4.1.132.Final"
-path = "./lib/netty-buffer-4.1.132.Final.jar"
+version = "4.1.133.Final"
+path = "./lib/netty-buffer-4.1.133.Final.jar"
 
 
 [[platform.java21.dependency]]
 groupId = "io.netty"
 artifactId = "netty-codec"
-version = "4.1.132.Final"
-path = "./lib/netty-codec-4.1.132.Final.jar"
+version = "4.1.133.Final"
+path = "./lib/netty-codec-4.1.133.Final.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.netty"
 artifactId = "netty-codec-dns"
-version = "4.1.132.Final"
-path = "./lib/netty-codec-dns-4.1.132.Final.jar"
+version = "4.1.133.Final"
+path = "./lib/netty-codec-dns-4.1.133.Final.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.netty"
 artifactId = "netty-codec-http"
-version = "4.1.132.Final"
-path = "./lib/netty-codec-http-4.1.132.Final.jar"
+version = "4.1.133.Final"
+path = "./lib/netty-codec-http-4.1.133.Final.jar"
 
 
 [[platform.java21.dependency]]
 groupId = "io.netty"
 artifactId = "netty-codec-http2"
-version = "4.1.132.Final"
-path = "./lib/netty-codec-http2-4.1.132.Final.jar"
+version = "4.1.133.Final"
+path = "./lib/netty-codec-http2-4.1.133.Final.jar"
 
 
 [[platform.java21.dependency]]
 groupId = "io.netty"
 artifactId = "netty-codec-socks"
-version = "4.1.132.Final"
-path = "./lib/netty-codec-socks-4.1.132.Final.jar"
+version = "4.1.133.Final"
+path = "./lib/netty-codec-socks-4.1.133.Final.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.netty"
 artifactId = "netty-common"
-version = "4.1.132.Final"
-path = "./lib/netty-common-4.1.132.Final.jar"
+version = "4.1.133.Final"
+path = "./lib/netty-common-4.1.133.Final.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.netty"
 artifactId = "netty-handler"
-version = "4.1.132.Final"
-path = "./lib/netty-handler-4.1.132.Final.jar"
+version = "4.1.133.Final"
+path = "./lib/netty-handler-4.1.133.Final.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.netty"
 artifactId = "netty-handler-proxy"
-version = "4.1.132.Final"
-path = "./lib/netty-handler-proxy-4.1.132.Final.jar"
+version = "4.1.133.Final"
+path = "./lib/netty-handler-proxy-4.1.133.Final.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.netty"
 artifactId = "netty-resolver"
-version = "4.1.132.Final"
-path = "./lib/netty-resolver-4.1.132.Final.jar"
+version = "4.1.133.Final"
+path = "./lib/netty-resolver-4.1.133.Final.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.netty"
 artifactId = "netty-resolver-dns"
-version = "4.1.132.Final"
-path = "./lib/netty-resolver-dns-4.1.132.Final.jar"
+version = "4.1.133.Final"
+path = "./lib/netty-resolver-dns-4.1.133.Final.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.netty"
 artifactId = "netty-resolver-dns-classes-macos"
-version = "4.1.132.Final"
-path = "./lib/netty-resolver-dns-classes-macos-4.1.132.Final.jar"
+version = "4.1.133.Final"
+path = "./lib/netty-resolver-dns-classes-macos-4.1.133.Final.jar"
 
 [[platform.java21.dependency]]
-path = "./lib/netty-resolver-dns-native-macos-4.1.132.Final-osx-x86_64.jar"
+path = "./lib/netty-resolver-dns-native-macos-4.1.133.Final-osx-x86_64.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.netty"
 artifactId = "netty-transport"
-version = "4.1.132.Final"
-path = "./lib/netty-transport-4.1.132.Final.jar"
+version = "4.1.133.Final"
+path = "./lib/netty-transport-4.1.133.Final.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.netty"
 artifactId = "netty-transport-classes-epoll"
-version = "4.1.132.Final"
-path = "./lib/netty-transport-classes-epoll-4.1.132.Final.jar"
+version = "4.1.133.Final"
+path = "./lib/netty-transport-classes-epoll-4.1.133.Final.jar"
 
 [[platform.java21.dependency]]
-path = "./lib/netty-transport-native-epoll-4.1.132.Final-linux-x86_64.jar"
+path = "./lib/netty-transport-native-epoll-4.1.133.Final-linux-x86_64.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.netty"
 artifactId = "netty-transport-classes-kqueue"
-version = "4.1.132.Final"
-path = "./lib/netty-transport-classes-kqueue-4.1.132.Final.jar"
+version = "4.1.133.Final"
+path = "./lib/netty-transport-classes-kqueue-4.1.133.Final.jar"
 
 [[platform.java21.dependency]]
-path = "./lib/netty-transport-native-kqueue-4.1.132.Final-osx-x86_64.jar"
+path = "./lib/netty-transport-native-kqueue-4.1.133.Final-osx-x86_64.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.netty"
 artifactId = "netty-transport-native-unix-common"
-version = "4.1.132.Final"
-path = "./lib/netty-transport-native-unix-common-4.1.132.Final.jar"
+version = "4.1.133.Final"
+path = "./lib/netty-transport-native-unix-common-4.1.133.Final.jar"
 
 # Netty tcnative dependencies
 [[platform.java21.dependency]]

--- a/gradle.properties
+++ b/gradle.properties
@@ -28,7 +28,7 @@ jacksonDatatypeJsrVersion=2.18.6
 jacksonDataFormatXmlVersion=2.18.6
 
 # Netty dependencies
-nettyVersion=4.1.132.Final
+nettyVersion=4.1.133.Final
 nettyTcnativeVersion=2.0.74.Final
 
 # Reactor dependencies


### PR DESCRIPTION
## Purpose
> $subject

Fixes: https://github.com/ballerina-platform/ballerina-library/issues/8787

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This pull request updates the Netty framework dependency from version 4.1.132.Final to 4.1.133.Final across the module's Java 21 platform configuration. The update ensures the connector uses a more stable and reliable version of Netty, addressing known issues in the previous release.

## Changes

- **gradle.properties**: Updated the `nettyVersion` property to `4.1.133.Final`
- **ballerina/Ballerina.toml**: Updated all Netty artifact entries under the Java 21 platform dependencies section to use the newer version, including core modules, codecs, transports, resolver/native variants, and Unix common libraries with corresponding JAR path references

The changes are minimal and focused, affecting only the version declarations of Netty artifacts without modifications to other dependencies or configuration logic.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ballerina-platform/module-ballerinax-asb/pull/272)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->